### PR TITLE
Varoita tulosluettelossa, jos vartio saa tehtävästä enemmän kuin tehtävän max pisteet

### DIFF
--- a/web/fixtures/tests/max_pisteet_ylitetty.xml
+++ b/web/fixtures/tests/max_pisteet_ylitetty.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<django-objects version="1.0">
+    <object pk="8" model="tupa.kisa">
+        <field type="CharField" name="nimi">max_pisteet_ylitetty</field>
+        <field type="CharField" name="aika"></field>
+        <field type="CharField" name="paikka"></field>
+        <field type="BooleanField" name="tunnistus">False</field>
+    </object>
+    <object pk="18" model="tupa.sarja">
+        <field type="CharField" name="nimi">testi</field>
+        <field type="IntegerField" name="vartion_maksimikoko"><None></None></field>
+        <field type="IntegerField" name="vartion_minimikoko"><None></None></field>
+        <field to="tupa.kisa" name="kisa" rel="ManyToOneRel">8</field>
+        <field type="IntegerField" name="tasapiste_teht1">1</field>
+        <field type="IntegerField" name="tasapiste_teht2">2</field>
+        <field type="IntegerField" name="tasapiste_teht3">3</field>
+    </object>
+    <object pk="185" model="tupa.vartio">
+        <field type="IntegerField" name="nro">101</field>
+        <field type="CharField" name="nimi">vartio1</field>
+        <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">18</field>
+        <field type="CharField" name="piiri"></field>
+        <field type="CharField" name="lippukunta"></field>
+        <field type="CharField" name="puhelinnro"></field>
+        <field type="CharField" name="sahkoposti"></field>
+        <field type="CharField" name="osoite"></field>
+        <field type="IntegerField" name="keskeyttanyt"><None></None></field>
+        <field type="IntegerField" name="ulkopuolella"><None></None></field>
+    </object>
+    <object pk="186" model="tupa.vartio">
+        <field type="IntegerField" name="nro">102</field>
+        <field type="CharField" name="nimi">vartio2</field>
+        <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">18</field>
+        <field type="CharField" name="piiri"></field>
+        <field type="CharField" name="lippukunta"></field>
+        <field type="CharField" name="puhelinnro"></field>
+        <field type="CharField" name="sahkoposti"></field>
+        <field type="CharField" name="osoite"></field>
+        <field type="IntegerField" name="keskeyttanyt"><None></None></field>
+        <field type="IntegerField" name="ulkopuolella"><None></None></field>
+    </object>
+    <object pk="261" model="tupa.tehtava">
+        <field type="CharField" name="nimi">testi</field>
+        <field type="CharField" name="lyhenne"></field>
+        <field type="CharField" name="tehtavaryhma"></field>
+        <field type="CharField" name="tehtavaluokka"></field>
+        <field type="TextField" name="rastikasky"></field>
+        <field type="IntegerField" name="jarjestysnro">1</field>
+        <field type="CharField" name="kaava">ss</field>
+        <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">18</field>
+        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="CharField" name="maksimipisteet">3</field>
+        <field type="BooleanField" name="svirhe">False</field>
+    </object>
+    <object pk="2601" model="tupa.testaustulos">
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">185</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">261</field>
+        <field type="CharField" name="pisteet">2.5</field>
+    </object>
+    <object pk="2602" model="tupa.testaustulos">
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">186</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">261</field>
+        <field type="CharField" name="pisteet">3.5 (?)</field>
+    </object>
+    <object pk="1351" model="tupa.syotemaarite">
+        <field type="CharField" name="nimi">a</field>
+        <field type="CharField" name="tyyppi">piste</field>
+        <field type="CharField" name="kali_vihje">pisteet</field>
+        <field to="tupa.osatehtava" name="osa_tehtava" rel="ManyToOneRel">527</field>
+    </object>
+    <object pk="22300" model="tupa.syote">
+        <field type="CharField" name="arvo">2.5</field>
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">185</field>
+        <field to="tupa.syotemaarite" name="maarite" rel="ManyToOneRel">1351</field>
+        <field type="CharField" name="tarkistus"></field>
+    </object>
+    <object pk="22301" model="tupa.syote">
+        <field type="CharField" name="arvo">3.5</field>
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">186</field>
+        <field to="tupa.syotemaarite" name="maarite" rel="ManyToOneRel">1351</field>
+        <field type="CharField" name="tarkistus"></field>
+    </object>
+    <object pk="527" model="tupa.osatehtava">
+        <field type="CharField" name="nimi">a</field>
+        <field type="CharField" name="tyyppi">kp</field>
+        <field type="CharField" name="kaava">a</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">261</field>
+    </object>
+    <object pk="262" model="tupa.tehtava">
+        <field type="CharField" name="nimi">testi_2</field>
+        <field type="CharField" name="lyhenne"></field>
+        <field type="CharField" name="tehtavaryhma"></field>
+        <field type="CharField" name="tehtavaluokka"></field>
+        <field type="TextField" name="rastikasky"></field>
+        <field type="IntegerField" name="jarjestysnro">2</field>
+        <field type="CharField" name="kaava">ss</field>
+        <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">18</field>
+        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="CharField" name="maksimipisteet">3</field>
+        <field type="BooleanField" name="svirhe">False</field>
+    </object>
+    <object pk="2603" model="tupa.testaustulos">
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">185</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">262</field>
+        <field type="CharField" name="pisteet">3.5 (?)</field>
+    </object>
+    <object pk="2604" model="tupa.testaustulos">
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">186</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">262</field>
+        <field type="CharField" name="pisteet">H</field>
+    </object>
+    <object pk="1352" model="tupa.syotemaarite">
+        <field type="CharField" name="nimi">a</field>
+        <field type="CharField" name="tyyppi">piste</field>
+        <field type="CharField" name="kali_vihje">testi</field>
+        <field to="tupa.osatehtava" name="osa_tehtava" rel="ManyToOneRel">528</field>
+    </object>
+    <object pk="22302" model="tupa.syote">
+        <field type="CharField" name="arvo">7.0</field>
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">185</field>
+        <field to="tupa.syotemaarite" name="maarite" rel="ManyToOneRel">1352</field>
+        <field type="CharField" name="tarkistus"></field>
+    </object>
+    <object pk="22303" model="tupa.syote">
+        <field type="CharField" name="arvo">h</field>
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">186</field>
+        <field to="tupa.syotemaarite" name="maarite" rel="ManyToOneRel">1352</field>
+        <field type="CharField" name="tarkistus"></field>
+    </object>
+    <object pk="4117" model="tupa.parametri">
+        <field type="CharField" name="nimi">vartion_kaava</field>
+        <field type="CharField" name="arvo">a*0.5</field>
+        <field to="tupa.osatehtava" name="osa_tehtava" rel="ManyToOneRel">528</field>
+    </object>
+    <object pk="528" model="tupa.osatehtava">
+        <field type="CharField" name="nimi">a</field>
+        <field type="CharField" name="tyyppi">pk</field>
+        <field type="CharField" name="kaava">vartion_kaava</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">262</field>
+    </object>
+    <object pk="263" model="tupa.tehtava">
+        <field type="CharField" name="nimi">tyhja_max_pisteet</field>
+        <field type="CharField" name="lyhenne"></field>
+        <field type="CharField" name="tehtavaryhma"></field>
+        <field type="CharField" name="tehtavaluokka"></field>
+        <field type="TextField" name="rastikasky"></field>
+        <field type="IntegerField" name="jarjestysnro">3</field>
+        <field type="CharField" name="kaava">ss</field>
+        <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">18</field>
+        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="CharField" name="maksimipisteet"></field>
+        <field type="BooleanField" name="svirhe">False</field>
+    </object>
+    <object pk="2605" model="tupa.testaustulos">
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">185</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">263</field>
+        <field type="CharField" name="pisteet">5.0</field>
+    </object>
+    <object pk="2606" model="tupa.testaustulos">
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">186</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">263</field>
+        <field type="CharField" name="pisteet">2.0</field>
+    </object>
+    <object pk="1353" model="tupa.syotemaarite">
+        <field type="CharField" name="nimi">a</field>
+        <field type="CharField" name="tyyppi">piste</field>
+        <field type="CharField" name="kali_vihje">syöte</field>
+        <field to="tupa.osatehtava" name="osa_tehtava" rel="ManyToOneRel">529</field>
+    </object>
+    <object pk="22304" model="tupa.syote">
+        <field type="CharField" name="arvo">5.0</field>
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">185</field>
+        <field to="tupa.syotemaarite" name="maarite" rel="ManyToOneRel">1353</field>
+        <field type="CharField" name="tarkistus"></field>
+    </object>
+    <object pk="22305" model="tupa.syote">
+        <field type="CharField" name="arvo">2.0</field>
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">186</field>
+        <field to="tupa.syotemaarite" name="maarite" rel="ManyToOneRel">1353</field>
+        <field type="CharField" name="tarkistus"></field>
+    </object>
+    <object pk="529" model="tupa.osatehtava">
+        <field type="CharField" name="nimi">a</field>
+        <field type="CharField" name="tyyppi">kp</field>
+        <field type="CharField" name="kaava">a</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">263</field>
+    </object>
+</django-objects>

--- a/web/tupa/TulosLaskin.py
+++ b/web/tupa/TulosLaskin.py
@@ -300,10 +300,14 @@ def laskeSarja(sarja,syotteet,vartiot=None,tehtavat=None):
                 # Lisää varoitus, jos vartion pisteet ylittävät tehtävän max. pisteet
                 for t in range(len(tulokset[i])) :
                         pisteet = tulokset[i][t]
+                        # Tarkistetaan, että pisteet on laskettu (numeerinen arvo).
+                        # Vartion pisteet voivat olla myös esim. H, E tai K (katso
+                        # silmukka vähän ylempää), tällöin tarkistus on turha.
                         if (pisteet and type(pisteet) != str and type(pisteet) != unicode) :
+                                # Onko pisteet > max pisteet
                                 if pisteet > float(tehtavat[t].maksimipisteet):
+                                        # Lisää huomautus tulosluetteloon
                                         tulokset[i][t] = str(tulokset[i][t]) + " (?)"
-
 
                 #Kokonaispisteet:
                 summa=0

--- a/web/tupa/TulosLaskin.py
+++ b/web/tupa/TulosLaskin.py
@@ -19,10 +19,10 @@ import log
 def korvaa(lause,pino,loppu=None) :
     """
     Korvaa lauseen muuttujat pinon mukaisella etuliitteella a.b.c jne.
-    "." lausessa muuttujan edessa liikuttaa muuttujaa pinossa ylospain 
-    optionaalinen loppu parametri lisaa muuttujan peraan arvon. 
+    "." lausessa muuttujan edessa liikuttaa muuttujaa pinossa ylospain
+    optionaalinen loppu parametri lisaa muuttujan peraan arvon.
     loppu parametri poistuu ensimmaisella .a operaatiola
-    esim: 
+    esim:
     >>> korvaa("c",["a","b"])
     'a.b.c'
     >>> korvaa(".c",["a","b"])
@@ -49,10 +49,10 @@ def korvaa(lause,pino,loppu=None) :
     '56'
     """
     # Ensiksi täytyy poistaa kaikki x..y -> y
-    poistoon= re.search(r"([^-.+*/(),]+[.][.])",lause) 
+    poistoon= re.search(r"([^-.+*/(),]+[.][.])",lause)
     while poistoon :
         lause=re.sub(r"([^-.+*/()]+[.][.])","",lause,count=1)
-        poistoon= re.search(r"([^-.+*/()]+[.][.])",lause) 
+        poistoon= re.search(r"([^-.+*/()]+[.][.])",lause)
     haku= re.finditer("(?<![]])(\.{0,3})([a-zA-Z]\w*)(?:\.(\w+))?(?:\.(\w+))?(?:\.(\w+))?(?!\w*[(])",lause )
     muutokset=[]
     for h in haku :
@@ -66,11 +66,11 @@ def korvaa(lause,pino,loppu=None) :
             for i in range(kohtaan) :
                 uusi=uusi+"." +pino[i]
             for g in ryhmat[1:] :
-                if g: 
+                if g:
                     uusi=uusi+"."+g
                     vanha=vanha+"."+g
             vanha=vanha[1:]
-            if loppu and len(ryhmat[0])==0: 
+            if loppu and len(ryhmat[0])==0:
                 uusi=uusi+"."+loppu
             uusi=uusi[1:]
             muutokset.append((h.start(),h.end(),uusi))
@@ -98,7 +98,7 @@ def suoritusJoukko(s) :
     return muokattu
 
 def luoMuuttujat(vartiot,tehtavat,syotteet) :
-    """ 
+    """
     Luo sarjan syotteiden muuttujasanakirjan:
     rakenne on muotoa: muuttujat[tehtavan_nimi][osatatehtavan_nimi][syotteen_nimi][vartion_nro]=arvo
     mukana olevien vartioista loytyy tieto: muuttujat[tehtavan_nimi]["mukana"][vartion_nro]=1
@@ -120,10 +120,10 @@ def luoMuuttujat(vartiot,tehtavat,syotteet) :
                 dict_syotteet=[]
                 for v in vartiot :
                     s=maaritteen_syotteet.filter(vartio=v)
-                    if len(s)==1 : 
+                    if len(s)==1 :
                         try :
                             dict_syotteet.append((str(v.nro),DictDecimal(s[0].arvo)))
-                        except InvalidOperation: 
+                        except InvalidOperation:
                             if not s[0].arvo=="kesk":
                                 dict_syotteet.append((str(v.nro),s[0].arvo))
                         except TypeError : pass
@@ -142,7 +142,7 @@ def luoOsatehtavanKaava(ot_lause,parametrit):
     -Toteuttaa muk -> ..mukana pikatien
     -Muuntaa suor pikatien kaikkien vartioiden suorituksiin parametristä vartion_kaava
     """
-    ot_lause #=ot.kaava #.lower() 
+    ot_lause #=ot.kaava #.lower()
     log.logString( "  kaava = " + ot_lause )
     korvautuu=True
 
@@ -156,7 +156,7 @@ def luoOsatehtavanKaava(ot_lause,parametrit):
         vanha=ot_lause
         for p_nimi,p_arvo in parametrit.items():
             ot_lause=re.sub(p_nimi+r"(?!\w+)",p_arvo,ot_lause)
-        # Pikatie "muk" -> "..mukana" 
+        # Pikatie "muk" -> "..mukana"
         ot_lause=re.sub("muk"+r"(?!\w+)","..mukana",ot_lause)
         # Muunnos "suor" -> kaikkien vartioiden lasketut suoritukset
         try:
@@ -171,19 +171,19 @@ def luoOsatehtavanKaava(ot_lause,parametrit):
     return ot_lause
 
 def luoTehtavanKaava(t,v):
-        pino=[] # Pinoon laitetaan kulloinenkin iterointipolku, 
+        pino=[] # Pinoon laitetaan kulloinenkin iterointipolku,
                 #jotta muuttujan nimet voidaan muuttaa suhteellisesta kirjaimesta absoluuttiseen polkuun.
         t_nimi= t.nimi.replace(" ","").replace("!","").lower()
         pino.append(t_nimi)
         osatehtavat=t.osatehtava_set.all()
         ot_lauseet=[]
-        
+
         log.logString( u"<h3>Tehtävä: " + t.nimi.upper()+"</h3>" )
         if t.kaava.upper()=="SS" :
                 log.logString( u"kaava = ⚡⚡" )
         else:
                 log.logString( u"kaava =  " + t.kaava.upper() )
-        
+
         for ot in osatehtavat:
                 log.logString( u"\n<b>Osatehtävä: " + ot.nimi.upper()+"</b>" )
                 pino.append(ot.nimi)
@@ -196,7 +196,7 @@ def luoTehtavanKaava(t,v):
                         for m in maaritteet:
                                 ot_lause=ot_lause+m.nimi+"+"
                         ot_lause=ot_lause[:-1]
-                
+
                 parametrit={}
                 for p in ot.parametri_set.all():
                         parametrit[p.nimi]=p.arvo
@@ -209,12 +209,12 @@ def luoTehtavanKaava(t,v):
                         if not ot_lause==vanha : korvautuu=True
 
                 log.logString( "  sijoitettu = " + ot_lause )
-                     
-                # Muutetaan muuttujien nimet koko polun mittaisiksi: 
+
+                # Muutetaan muuttujien nimet koko polun mittaisiksi:
                 #tehtava(nimi).osatehtava(nimi).syote(nimi).vartio(nro)
                 ot_lause=korvaa(ot_lause,pino,str(v.nro))
                 # Pikatie vartio -> vartion numero
-                ot_lause=re.sub("vartio"+r"(?!\w+)", str(v.nro) ,ot_lause)        
+                ot_lause=re.sub("vartio"+r"(?!\w+)", str(v.nro) ,ot_lause)
                 ot_lauseet.append((ot.nimi,ot_lause))
                 pino.pop()
         tehtava_lause=""
@@ -246,13 +246,13 @@ def luoLaskut(vartiot,tehtavat) :
 
 def laskeSarja(sarja,syotteet,vartiot=None,tehtavat=None):
         """
-        Laskee tulokset halutulle sarjalle. 
+        Laskee tulokset halutulle sarjalle.
         Palauttaa kaksiuloitteisen taulukon[vartio][tehtävä] = pisteet.
         Taulukon ensimmäisissä sarakkeissa on vartio tai tehtävä objekteja muissa pisteitä.
         Taulukon vasemmassa ylänurkassa on sarjan objekti
         """
         #syotteetr=Syote.objects.all() #(maarite__osa_tehtava__tehtava__sarja=sarja )
-        
+
         if not vartiot : vartiot=sarja.vartio_set.all()
         if not tehtavat: tehtavat=sarja.tehtava_set.all()
         if vartiot and tehtavat : jee=1 # Pakotetaan tietokantahaku.
@@ -274,12 +274,12 @@ def laskeSarja(sarja,syotteet,vartiot=None,tehtavat=None):
                         for s in tehtSyotteet :
                                 if s.arvo=="e" : tekematta=True
                                 if not s.arvo=="h":  hylatty=False
-                        
+
                         if hylatty and len(tehtSyotteet): tulokset[i][t]= "H"
                         if tekematta: tulokset[i][t]= "E"
 
                 #Merkataan siirrettäviksi ulkopuolella olevat:
-                if not vartiot[i].keskeyttanyt == None or not vartiot[i].ulkopuolella == None : 
+                if not vartiot[i].keskeyttanyt == None or not vartiot[i].ulkopuolella == None :
                         #Merkataan keskeyttaneille tuloksiin "K" keskeyttämisestä eteenpäin
                         if not vartiot[i].keskeyttanyt==None:
                                 kesk=vartiot[i].keskeyttanyt-1
@@ -292,18 +292,27 @@ def laskeSarja(sarja,syotteet,vartiot=None,tehtavat=None):
                                 tuom=vartion_tuomarit.filter(tehtava=tehtavat[t])
                                 if len(tuom) :
                                         log.logString( u"Tuomarineuvoston ylimääritys: " + str(tuom[0].pisteet) )
-                                        try: 
+                                        try:
                                                 tulokset[i][t]= Decimal(tuom[0].pisteet)
                                         except:
                                                 tulokset[i][t]= tuom[0].pisteet
+
+                # Lisää varoitus, jos vartion pisteet ylittävät tehtävän max. pisteet
+                for t in range(len(tulokset[i])) :
+                        pisteet = tulokset[i][t]
+                        if (pisteet and type(pisteet) != str and type(pisteet) != unicode) :
+                                if pisteet > float(tehtavat[t].maksimipisteet):
+                                        tulokset[i][t] = str(tulokset[i][t]) + " (?)"
+
+
                 #Kokonaispisteet:
                 summa=0
                 for s in tulokset[i] :
-                        if s and type(s)!=str and type(s)!=unicode : summa+= s 
+                        if s and type(s)!=str and type(s)!=unicode : summa+= s
                 tulokset[i].insert(0,summa)
                 #Vartio objekti jokaisen rivin alkuun:
                 tulokset[i].insert(0,vartiot[i])
-        
+
         # Kirjataan välivaiheisiin lopputulos
         try:
                 log.logString( "\n<b>TULOS = " + str(tulokset[0][2])+"</b>" )
@@ -336,7 +345,7 @@ def laskeSarja(sarja,syotteet,vartiot=None,tehtavat=None):
         if sarja.tasapiste_teht1 : tasa1 = sarja.tasapiste_teht1+1
         if sarja.tasapiste_teht2 : tasa2 = sarja.tasapiste_teht2+1
         if sarja.tasapiste_teht2 : tasa3 = sarja.tasapiste_teht3+1
-        
+
         tulokset.sort(key=operator.itemgetter(1) ,reverse=True)
         ulkona.sort(key=operator.itemgetter(1) ,reverse=True)
         #Järjestetään taulukot
@@ -345,7 +354,7 @@ def laskeSarja(sarja,syotteet,vartiot=None,tehtavat=None):
                 ulkona.sort( key=operator.itemgetter(1,tasa1,tasa2,tasa3),reverse=True )
         except : # tehtäviä < 3
 		        pass
-        
+
         # Etsitään tasapistetulokset :
         edellinen=None
         for vi, vartio in enumerate(ulkona) :
@@ -363,7 +372,7 @@ def laskeSarja(sarja,syotteet,vartiot=None,tehtavat=None):
                 edellinen = vartio
         #Lisätään tehtävärivi ylos
         mukana.insert(0,t_list)
-        
+
         return (mukana,ulkona)
 
 if __name__ == "__main__":

--- a/web/tupa/TulosLaskin.py
+++ b/web/tupa/TulosLaskin.py
@@ -303,7 +303,7 @@ def laskeSarja(sarja,syotteet,vartiot=None,tehtavat=None):
                         # Tarkistetaan, että pisteet on laskettu (numeerinen arvo).
                         # Vartion pisteet voivat olla myös esim. H, E tai K (katso
                         # silmukka vähän ylempää), tällöin tarkistus on turha.
-                        if (pisteet and type(pisteet) != str and type(pisteet) != unicode) :
+                        if (pisteet and type(pisteet) != str and type(pisteet) != unicode and tehtavat[t].maksimipisteet != '') :
                                 # Onko pisteet > max pisteet
                                 if pisteet > float(tehtavat[t].maksimipisteet):
                                         # Lisää huomautus tulosluetteloon


### PR DESCRIPTION
Lisää tulosluetteloon varoitus, jos vartio saa yli max pisteet tehtävästä. (Tämä voi olla mahdollista, jos kaava on tehty väärin.) 

Tulospäällikkö voi pelastaa nahkansa ja tarkistaa kaavat ennen julkista nöyryytystä.