### PR TITLE
Piilota tulokset, joita ei ole tarkistettu

### DIFF
--- a/web/fixtures/tests/aikavali_naapuriin.xml
+++ b/web/fixtures/tests/aikavali_naapuriin.xml
@@ -59,7 +59,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">16</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet">5</field>
     </object>
     <object pk="1449" model="tupa.testaustulos">
@@ -137,7 +137,7 @@
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">16</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="1452" model="tupa.testaustulos">

--- a/web/fixtures/tests/ainoa_teht.xml
+++ b/web/fixtures/tests/ainoa_teht.xml
@@ -35,7 +35,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="1" model="tupa.syotemaarite">

--- a/web/fixtures/tests/arvio_oikea.xml
+++ b/web/fixtures/tests/arvio_oikea.xml
@@ -91,7 +91,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">7</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="728" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">59</field>
@@ -224,7 +224,7 @@
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">7</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="734" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">59</field>

--- a/web/fixtures/tests/don_huonot.xml
+++ b/web/fixtures/tests/don_huonot.xml
@@ -59,7 +59,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">31</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet">6</field>
     </object>
     <object pk="2338" model="tupa.testaustulos">
@@ -161,7 +161,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">31</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet">5</field>
     </object>
     <object pk="335" model="tupa.syotemaarite">
@@ -248,7 +248,7 @@
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">31</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet">5</field>
     </object>
     <object pk="336" model="tupa.syotemaarite">

--- a/web/fixtures/tests/e_bugaa.xml
+++ b/web/fixtures/tests/e_bugaa.xml
@@ -84,7 +84,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">15</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet">4</field>
         <field type="BooleanField" name="svirhe">False</field>
     </object>

--- a/web/fixtures/tests/e_bugaa_lista.xml
+++ b/web/fixtures/tests/e_bugaa_lista.xml
@@ -568,7 +568,7 @@
         <field type="IntegerField" name="jarjestysnro">12</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">18</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
         <field type="BooleanField" name="svirhe">False</field>
     </object>
@@ -838,7 +838,7 @@
         <field type="IntegerField" name="jarjestysnro">13</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">18</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
         <field type="BooleanField" name="svirhe">False</field>
     </object>

--- a/web/fixtures/tests/h_aikavali_kaataa.xml
+++ b/web/fixtures/tests/h_aikavali_kaataa.xml
@@ -31,7 +31,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">3</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="54" model="tupa.syotemaarite">
         <field type="CharField" name="nimi">a</field>

--- a/web/fixtures/tests/hylatty_perusfunktio.xml
+++ b/web/fixtures/tests/hylatty_perusfunktio.xml
@@ -71,7 +71,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">22</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="2196" model="tupa.testaustulos">

--- a/web/fixtures/tests/interpoloi.xml
+++ b/web/fixtures/tests/interpoloi.xml
@@ -295,6 +295,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="24" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">4</field>
@@ -858,6 +859,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">3</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="1" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">27</field>

--- a/web/fixtures/tests/jarjestys.xml
+++ b/web/fixtures/tests/jarjestys.xml
@@ -59,7 +59,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">15</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="2559" model="tupa.testaustulos">

--- a/web/fixtures/tests/jebou.xml
+++ b/web/fixtures/tests/jebou.xml
@@ -254,7 +254,7 @@
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="2" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>

--- a/web/fixtures/tests/k_suoritus.xml
+++ b/web/fixtures/tests/k_suoritus.xml
@@ -43,6 +43,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="5" model="tupa.syotemaarite">
         <field type="CharField" name="nimi">a</field>
@@ -88,6 +89,7 @@
         <field type="TextField" name="rastikasky"></field>
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">ss</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
     </object>
     <object pk="6" model="tupa.syotemaarite">

--- a/web/fixtures/tests/kaavassa_isoja_ja_pienia_kirjaimia.xml
+++ b/web/fixtures/tests/kaavassa_isoja_ja_pienia_kirjaimia.xml
@@ -35,7 +35,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">sS</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet">4</field>
     </object>
     <object pk="2190" model="tupa.testaustulos">

--- a/web/fixtures/tests/keskeyttanyt_0.xml
+++ b/web/fixtures/tests/keskeyttanyt_0.xml
@@ -119,7 +119,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">1</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">15</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="9" model="tupa.testaustulos">
@@ -183,7 +183,7 @@
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">1</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">15</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="17" model="tupa.testaustulos">
@@ -247,7 +247,7 @@
         <field type="IntegerField" name="jarjestysnro">3</field>
         <field type="CharField" name="kaava">1</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">15</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="25" model="tupa.testaustulos">
@@ -311,7 +311,7 @@
         <field type="IntegerField" name="jarjestysnro">4</field>
         <field type="CharField" name="kaava">1</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">15</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="33" model="tupa.testaustulos">
@@ -375,7 +375,7 @@
         <field type="IntegerField" name="jarjestysnro">5</field>
         <field type="CharField" name="kaava">1</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">15</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="41" model="tupa.testaustulos">
@@ -439,7 +439,7 @@
         <field type="IntegerField" name="jarjestysnro">6</field>
         <field type="CharField" name="kaava">1</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">15</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="49" model="tupa.testaustulos">
@@ -503,7 +503,7 @@
         <field type="IntegerField" name="jarjestysnro">7</field>
         <field type="CharField" name="kaava">1</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">15</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="57" model="tupa.testaustulos">
@@ -567,7 +567,7 @@
         <field type="IntegerField" name="jarjestysnro">8</field>
         <field type="CharField" name="kaava">1</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">15</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="65" model="tupa.testaustulos">

--- a/web/fixtures/tests/kisat/punkku_09_skandeilla.xml
+++ b/web/fixtures/tests/kisat/punkku_09_skandeilla.xml
@@ -307,7 +307,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">max(0,a-b*0.5)</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="1" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -789,7 +789,7 @@
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="25" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -1240,7 +1240,7 @@
         <field type="IntegerField" name="jarjestysnro">3</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="49" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -1772,7 +1772,7 @@
         <field type="IntegerField" name="jarjestysnro">4</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="73" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -2103,7 +2103,7 @@
         <field type="IntegerField" name="jarjestysnro">5</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="97" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -2384,7 +2384,7 @@
         <field type="IntegerField" name="jarjestysnro">6</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="121" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -2715,7 +2715,7 @@
         <field type="IntegerField" name="jarjestysnro">7</field>
         <field type="CharField" name="kaava">a</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="145" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -3046,7 +3046,7 @@
         <field type="IntegerField" name="jarjestysnro">8</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="169" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -3377,7 +3377,7 @@
         <field type="IntegerField" name="jarjestysnro">9</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="193" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -3909,7 +3909,7 @@
         <field type="IntegerField" name="jarjestysnro">10</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="217" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -4190,7 +4190,7 @@
         <field type="IntegerField" name="jarjestysnro">11</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="241" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -4521,7 +4521,7 @@
         <field type="IntegerField" name="jarjestysnro">12</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="265" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -5003,7 +5003,7 @@
         <field type="IntegerField" name="jarjestysnro">13</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="289" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -5334,7 +5334,7 @@
         <field type="IntegerField" name="jarjestysnro">14</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="313" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -5665,7 +5665,7 @@
         <field type="IntegerField" name="jarjestysnro">15</field>
         <field type="CharField" name="kaava">a+b</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="337" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -6147,7 +6147,7 @@
         <field type="IntegerField" name="jarjestysnro">16</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="361" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -6478,7 +6478,7 @@
         <field type="IntegerField" name="jarjestysnro">17</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="385" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -6759,7 +6759,7 @@
         <field type="IntegerField" name="jarjestysnro">18</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="409" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -7202,7 +7202,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">max(0,a-b*0.5)</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="433" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -7495,7 +7495,7 @@
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="446" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -7762,7 +7762,7 @@
         <field type="IntegerField" name="jarjestysnro">3</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="459" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -8065,7 +8065,7 @@
         <field type="IntegerField" name="jarjestysnro">4</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="472" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -8254,7 +8254,7 @@
         <field type="IntegerField" name="jarjestysnro">5</field>
         <field type="CharField" name="kaava">a+b</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="485" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -8547,7 +8547,7 @@
         <field type="IntegerField" name="jarjestysnro">6</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="498" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -8736,7 +8736,7 @@
         <field type="IntegerField" name="jarjestysnro">7</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="511" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -8915,7 +8915,7 @@
         <field type="IntegerField" name="jarjestysnro">8</field>
         <field type="CharField" name="kaava">a</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="524" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -9104,7 +9104,7 @@
         <field type="IntegerField" name="jarjestysnro">9</field>
         <field type="CharField" name="kaava">a</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="537" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -9293,7 +9293,7 @@
         <field type="IntegerField" name="jarjestysnro">10</field>
         <field type="CharField" name="kaava">a</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="550" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -9482,7 +9482,7 @@
         <field type="IntegerField" name="jarjestysnro">11</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="563" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -9671,7 +9671,7 @@
         <field type="IntegerField" name="jarjestysnro">12</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="576" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -9850,7 +9850,7 @@
         <field type="IntegerField" name="jarjestysnro">13</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="589" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -10039,7 +10039,7 @@
         <field type="IntegerField" name="jarjestysnro">14</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="602" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -10332,7 +10332,7 @@
         <field type="IntegerField" name="jarjestysnro">15</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="615" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -10515,7 +10515,7 @@
         <field type="IntegerField" name="jarjestysnro">16</field>
         <field type="CharField" name="kaava">a+b</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="628" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -10808,7 +10808,7 @@
         <field type="IntegerField" name="jarjestysnro">17</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="641" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -10997,7 +10997,7 @@
         <field type="IntegerField" name="jarjestysnro">18</field>
         <field type="CharField" name="kaava">a</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="654" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -11186,7 +11186,7 @@
         <field type="IntegerField" name="jarjestysnro">19</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="667" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -11375,7 +11375,7 @@
         <field type="IntegerField" name="jarjestysnro">20</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="680" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -11564,7 +11564,7 @@
         <field type="IntegerField" name="jarjestysnro">21</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="693" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>
@@ -11743,7 +11743,7 @@
         <field type="IntegerField" name="jarjestysnro">22</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="706" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">25</field>

--- a/web/fixtures/tests/matikkafunktiot.xml
+++ b/web/fixtures/tests/matikkafunktiot.xml
@@ -31,7 +31,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">sqrt(2)</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">4</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="719" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">43</field>
@@ -58,7 +58,7 @@
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">abs(-18)</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">4</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="720" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">43</field>
@@ -85,7 +85,7 @@
         <field type="IntegerField" name="jarjestysnro">3</field>
         <field type="CharField" name="kaava">power(2,8)</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">4</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="721" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">43</field>
@@ -112,7 +112,7 @@
         <field type="IntegerField" name="jarjestysnro">4</field>
         <field type="CharField" name="kaava">ln(10)</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">4</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="722" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">43</field>
@@ -139,7 +139,7 @@
         <field type="IntegerField" name="jarjestysnro">5</field>
         <field type="CharField" name="kaava">log(10)</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">4</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="723" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">43</field>
@@ -166,7 +166,7 @@
         <field type="IntegerField" name="jarjestysnro">6</field>
         <field type="CharField" name="kaava">floor(10.332)</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">4</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="724" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">43</field>
@@ -193,7 +193,7 @@
         <field type="IntegerField" name="jarjestysnro">7</field>
         <field type="CharField" name="kaava">ceil(9.1)</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">4</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="725" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">43</field>
@@ -220,7 +220,7 @@
         <field type="IntegerField" name="jarjestysnro">8</field>
         <field type="CharField" name="kaava">mod(10,4)</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">4</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="726" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">43</field>
@@ -247,7 +247,7 @@
         <field type="IntegerField" name="jarjestysnro">9</field>
         <field type="CharField" name="kaava">exp(5)</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">4</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="727" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">43</field>

--- a/web/fixtures/tests/max_pisteet_ylitetty.xml
+++ b/web/fixtures/tests/max_pisteet_ylitetty.xml
@@ -48,7 +48,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">18</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet">3</field>
         <field type="BooleanField" name="svirhe">False</field>
     </object>
@@ -95,7 +95,7 @@
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">18</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet">3</field>
         <field type="BooleanField" name="svirhe">False</field>
     </object>
@@ -147,7 +147,7 @@
         <field type="IntegerField" name="jarjestysnro">3</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">18</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
         <field type="BooleanField" name="svirhe">False</field>
     </object>

--- a/web/fixtures/tests/missing_v_med.xml
+++ b/web/fixtures/tests/missing_v_med.xml
@@ -53,6 +53,7 @@
         <field type="CharField" name="tehtavaluokka"></field>
         <field type="TextField" name="rastikasky"></field>
         <field type="IntegerField" name="jarjestysnro">1</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="kaava">a+b</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
     </object>
@@ -176,6 +177,7 @@
         <field type="CharField" name="tehtavaluokka"></field>
         <field type="TextField" name="rastikasky"></field>
         <field type="IntegerField" name="jarjestysnro">2</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="kaava">A*10</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
     </object>
@@ -243,6 +245,7 @@
         <field type="TextField" name="rastikasky"></field>
         <field type="IntegerField" name="jarjestysnro">3</field>
         <field type="CharField" name="kaava">ss</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
     </object>
     <object pk="4" model="tupa.syotemaarite">
@@ -284,6 +287,7 @@
         <field type="TextField" name="rastikasky"></field>
         <field type="IntegerField" name="jarjestysnro">5</field>
         <field type="CharField" name="kaava">a+b</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
     </object>
     <object pk="6" model="tupa.syotemaarite">

--- a/web/fixtures/tests/naapurissa_syottamatta.xml
+++ b/web/fixtures/tests/naapurissa_syottamatta.xml
@@ -83,7 +83,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">17</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="1473" model="tupa.testaustulos">
@@ -225,7 +225,7 @@
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">17</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="1468" model="tupa.testaustulos">

--- a/web/fixtures/tests/naapuritehtava_interpoloinneissa.xml
+++ b/web/fixtures/tests/naapuritehtava_interpoloinneissa.xml
@@ -47,7 +47,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">17</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="131" model="tupa.syotemaarite">
@@ -146,7 +146,7 @@
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">17</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="1468" model="tupa.testaustulos">

--- a/web/fixtures/tests/nimi_paattyy_numeroon.xml
+++ b/web/fixtures/tests/nimi_paattyy_numeroon.xml
@@ -71,7 +71,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">a*b</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">32</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet">10</field>
     </object>
     <object pk="337" model="tupa.syotemaarite">
@@ -200,7 +200,7 @@
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">32</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet">5</field>
     </object>
     <object pk="339" model="tupa.syotemaarite">
@@ -283,7 +283,7 @@
         <field type="IntegerField" name="jarjestysnro">3</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">32</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet">5</field>
     </object>
     <object pk="341" model="tupa.syotemaarite">

--- a/web/fixtures/tests/nimissa_numeroita.xml
+++ b/web/fixtures/tests/nimissa_numeroita.xml
@@ -31,7 +31,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="1" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>

--- a/web/fixtures/tests/numero_t_nimi.xml
+++ b/web/fixtures/tests/numero_t_nimi.xml
@@ -71,7 +71,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">30</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="2552" model="tupa.testaustulos">

--- a/web/fixtures/tests/paska.xml
+++ b/web/fixtures/tests/paska.xml
@@ -56,7 +56,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">a+b</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">3</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="53" model="tupa.syotemaarite">
         <field type="CharField" name="nimi">fgjf</field>
@@ -112,7 +112,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">min</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">3</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="55" model="tupa.syotemaarite">
         <field type="CharField" name="nimi">min</field>
@@ -145,7 +145,7 @@
         <field type="IntegerField" name="jarjestysnro">6</field>
         <field type="CharField" name="kaava">interpoloi</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">3</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="54" model="tupa.osatehtava">
         <field type="CharField" name="nimi">interpoloi</field>
@@ -161,7 +161,7 @@
         <field type="IntegerField" name="jarjestysnro">7</field>
         <field type="CharField" name="kaava">max</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">3</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="56" model="tupa.syotemaarite">
         <field type="CharField" name="nimi">max</field>
@@ -189,7 +189,7 @@
         <field type="IntegerField" name="jarjestysnro">322</field>
         <field type="CharField" name="kaava">2*c-a</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">3</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="57" model="tupa.syotemaarite">
         <field type="CharField" name="nimi">a + b + c</field>

--- a/web/fixtures/tests/pelkka_numero_tehtavanimessa.xml
+++ b/web/fixtures/tests/pelkka_numero_tehtavanimessa.xml
@@ -95,7 +95,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">27</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="2264" model="tupa.testaustulos">

--- a/web/fixtures/tests/piste_a_vartio_vapaa_kaava.xml
+++ b/web/fixtures/tests/piste_a_vartio_vapaa_kaava.xml
@@ -59,7 +59,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">16</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="1465" model="tupa.testaustulos">

--- a/web/fixtures/tests/summa.xml
+++ b/web/fixtures/tests/summa.xml
@@ -59,7 +59,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">15</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="2559" model="tupa.testaustulos">

--- a/web/fixtures/tests/tarkistettu.xml
+++ b/web/fixtures/tests/tarkistettu.xml
@@ -1,0 +1,273 @@
+<?xml version="1.0" encoding="utf-8"?>
+<django-objects version="1.0">
+    <object pk="7" model="tupa.kisa">
+        <field type="CharField" name="nimi">tarkistettu</field>
+        <field type="CharField" name="aika"></field>
+        <field type="CharField" name="paikka"></field>
+        <field type="BooleanField" name="tunnistus">False</field>
+    </object>
+    <object pk="15" model="tupa.sarja">
+        <field type="CharField" name="nimi">testisarja</field>
+        <field type="IntegerField" name="vartion_maksimikoko"><None></None></field>
+        <field type="IntegerField" name="vartion_minimikoko"><None></None></field>
+        <field to="tupa.kisa" name="kisa" rel="ManyToOneRel">7</field>
+        <field type="IntegerField" name="tasapiste_teht1">1</field>
+        <field type="IntegerField" name="tasapiste_teht2">2</field>
+        <field type="IntegerField" name="tasapiste_teht3">3</field>
+    </object>
+    <object pk="101" model="tupa.vartio">
+        <field type="IntegerField" name="nro">1</field>
+        <field type="CharField" name="nimi">testi1</field>
+        <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">15</field>
+        <field type="CharField" name="piiri"></field>
+        <field type="CharField" name="lippukunta"></field>
+        <field type="CharField" name="puhelinnro"></field>
+        <field type="CharField" name="sahkoposti"></field>
+        <field type="CharField" name="osoite"></field>
+        <field type="IntegerField" name="keskeyttanyt"><None></None></field>
+        <field type="IntegerField" name="ulkopuolella"><None></None></field>
+    </object>
+    <object pk="102" model="tupa.vartio">
+        <field type="IntegerField" name="nro">2</field>
+        <field type="CharField" name="nimi">testi2</field>
+        <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">15</field>
+        <field type="CharField" name="piiri"></field>
+        <field type="CharField" name="lippukunta"></field>
+        <field type="CharField" name="puhelinnro"></field>
+        <field type="CharField" name="sahkoposti"></field>
+        <field type="CharField" name="osoite"></field>
+        <field type="IntegerField" name="keskeyttanyt"><None></None></field>
+        <field type="IntegerField" name="ulkopuolella"><None></None></field>
+    </object>
+    <object pk="103" model="tupa.vartio">
+        <field type="IntegerField" name="nro">3</field>
+        <field type="CharField" name="nimi">testi3</field>
+        <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">15</field>
+        <field type="CharField" name="piiri"></field>
+        <field type="CharField" name="lippukunta"></field>
+        <field type="CharField" name="puhelinnro"></field>
+        <field type="CharField" name="sahkoposti"></field>
+        <field type="CharField" name="osoite"></field>
+        <field type="IntegerField" name="keskeyttanyt"><None></None></field>
+        <field type="IntegerField" name="ulkopuolella"><None></None></field>
+    </object>
+    <object pk="179" model="tupa.tehtava">
+        <field type="CharField" name="nimi">testi1</field>
+        <field type="CharField" name="lyhenne"></field>
+        <field type="CharField" name="tehtavaryhma"></field>
+        <field type="CharField" name="tehtavaluokka"></field>
+        <field type="TextField" name="rastikasky"></field>
+        <field type="IntegerField" name="jarjestysnro">1</field>
+        <field type="CharField" name="kaava">ss</field>
+        <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">15</field>
+        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="CharField" name="maksimipisteet"></field>
+        <field type="BooleanField" name="svirhe">False</field>
+    </object>
+    <object pk="775" model="tupa.testaustulos">
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">101</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">179</field>
+        <field type="CharField" name="pisteet">S</field>
+    </object>
+    <object pk="776" model="tupa.testaustulos">
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">102</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">179</field>
+        <field type="CharField" name="pisteet">S</field>
+    </object>
+    <object pk="777" model="tupa.testaustulos">
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">103</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">179</field>
+        <field type="CharField" name="pisteet">S</field>
+    </object>
+    <object pk="501" model="tupa.syotemaarite">
+        <field type="CharField" name="nimi">a</field>
+        <field type="CharField" name="tyyppi">aika</field>
+        <field type="CharField" name="kali_vihje">aika</field>
+        <field to="tupa.osatehtava" name="osa_tehtava" rel="ManyToOneRel">343</field>
+    </object>
+    <object pk="3540" model="tupa.syote">
+        <field type="CharField" name="arvo">60</field>
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">101</field>
+        <field to="tupa.syotemaarite" name="maarite" rel="ManyToOneRel">501</field>
+        <field type="CharField" name="tarkistus">60.0</field>
+    </object>
+    <object pk="3541" model="tupa.syote">
+        <field type="CharField" name="arvo">90</field>
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">102</field>
+        <field to="tupa.syotemaarite" name="maarite" rel="ManyToOneRel">501</field>
+        <field type="CharField" name="tarkistus">90.0</field>
+    </object>
+    <object pk="3542" model="tupa.syote">
+        <field type="CharField" name="arvo">h</field>
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">103</field>
+        <field to="tupa.syotemaarite" name="maarite" rel="ManyToOneRel">501</field>
+        <field type="CharField" name="tarkistus">h</field>
+    </object>
+    <object pk="2682" model="tupa.parametri">
+        <field type="CharField" name="nimi">parhaan_kaava</field>
+        <field type="CharField" name="arvo">suor*muk</field>
+        <field to="tupa.osatehtava" name="osa_tehtava" rel="ManyToOneRel">343</field>
+    </object>
+    <object pk="2683" model="tupa.parametri">
+        <field type="CharField" name="nimi">oikea</field>
+        <field type="CharField" name="arvo">0</field>
+        <field to="tupa.osatehtava" name="osa_tehtava" rel="ManyToOneRel">343</field>
+    </object>
+    <object pk="2684" model="tupa.parametri">
+        <field type="CharField" name="nimi">jaettavat</field>
+        <field type="CharField" name="arvo">3</field>
+        <field to="tupa.osatehtava" name="osa_tehtava" rel="ManyToOneRel">343</field>
+    </object>
+    <object pk="2685" model="tupa.parametri">
+        <field type="CharField" name="nimi">nollan_kaava</field>
+        <field type="CharField" name="arvo">suor*muk</field>
+        <field to="tupa.osatehtava" name="osa_tehtava" rel="ManyToOneRel">343</field>
+    </object>
+    <object pk="2686" model="tupa.parametri">
+        <field type="CharField" name="nimi">parhaan_haku</field>
+        <field type="CharField" name="arvo">min</field>
+        <field to="tupa.osatehtava" name="osa_tehtava" rel="ManyToOneRel">343</field>
+    </object>
+    <object pk="2687" model="tupa.parametri">
+        <field type="CharField" name="nimi">vartion_kaava</field>
+        <field type="CharField" name="arvo">a</field>
+        <field to="tupa.osatehtava" name="osa_tehtava" rel="ManyToOneRel">343</field>
+    </object>
+    <object pk="2688" model="tupa.parametri">
+        <field type="CharField" name="nimi">tapa</field>
+        <field type="CharField" name="arvo">med</field>
+        <field to="tupa.osatehtava" name="osa_tehtava" rel="ManyToOneRel">343</field>
+    </object>
+    <object pk="2689" model="tupa.parametri">
+        <field type="CharField" name="nimi">arvio</field>
+        <field type="CharField" name="arvo"></field>
+        <field to="tupa.osatehtava" name="osa_tehtava" rel="ManyToOneRel">343</field>
+    </object>
+    <object pk="2690" model="tupa.parametri">
+        <field type="CharField" name="nimi">nollan_kerroin</field>
+        <field type="CharField" name="arvo">1.5</field>
+        <field to="tupa.osatehtava" name="osa_tehtava" rel="ManyToOneRel">343</field>
+    </object>
+    <object pk="343" model="tupa.osatehtava">
+        <field type="CharField" name="nimi">a</field>
+        <field type="CharField" name="tyyppi">ka</field>
+        <field type="CharField" name="kaava">max(interpoloi(parhaan_haku([arvio(vartion_kaava-oikea),nollan_kerroin*tapa(arvio(nollan_kaava-oikea))]),parhaan_haku(arvio(parhaan_kaava-oikea)),jaettavat,nollan_kerroin*tapa(arvio(nollan_kaava-oikea))))</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">179</field>
+    </object>
+    <object pk="180" model="tupa.tehtava">
+        <field type="CharField" name="nimi">testi2</field>
+        <field type="CharField" name="lyhenne"></field>
+        <field type="CharField" name="tehtavaryhma"></field>
+        <field type="CharField" name="tehtavaluokka"></field>
+        <field type="TextField" name="rastikasky"></field>
+        <field type="IntegerField" name="jarjestysnro">2</field>
+        <field type="CharField" name="kaava">ss</field>
+        <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">15</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
+        <field type="CharField" name="maksimipisteet">3</field>
+        <field type="BooleanField" name="svirhe">False</field>
+    </object>
+    <object pk="778" model="tupa.testaustulos">
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">101</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">180</field>
+        <field type="CharField" name="pisteet">2.0</field>
+    </object>
+    <object pk="779" model="tupa.testaustulos">
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">102</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">180</field>
+        <field type="CharField" name="pisteet">2.5</field>
+    </object>
+    <object pk="780" model="tupa.testaustulos">
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">103</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">180</field>
+        <field type="CharField" name="pisteet">E</field>
+    </object>
+    <object pk="502" model="tupa.syotemaarite">
+        <field type="CharField" name="nimi">a</field>
+        <field type="CharField" name="tyyppi">piste</field>
+        <field type="CharField" name="kali_vihje">pisteet</field>
+        <field to="tupa.osatehtava" name="osa_tehtava" rel="ManyToOneRel">344</field>
+    </object>
+    <object pk="3543" model="tupa.syote">
+        <field type="CharField" name="arvo">2.0</field>
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">101</field>
+        <field to="tupa.syotemaarite" name="maarite" rel="ManyToOneRel">502</field>
+        <field type="CharField" name="tarkistus"></field>
+    </object>
+    <object pk="3544" model="tupa.syote">
+        <field type="CharField" name="arvo">2.5</field>
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">102</field>
+        <field to="tupa.syotemaarite" name="maarite" rel="ManyToOneRel">502</field>
+        <field type="CharField" name="tarkistus"></field>
+    </object>
+    <object pk="3545" model="tupa.syote">
+        <field type="CharField" name="arvo">e</field>
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">103</field>
+        <field to="tupa.syotemaarite" name="maarite" rel="ManyToOneRel">502</field>
+        <field type="CharField" name="tarkistus"></field>
+    </object>
+    <object pk="344" model="tupa.osatehtava">
+        <field type="CharField" name="nimi">a</field>
+        <field type="CharField" name="tyyppi">kp</field>
+        <field type="CharField" name="kaava">a</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">180</field>
+    </object>
+    <object pk="181" model="tupa.tehtava">
+        <field type="CharField" name="nimi">testi3</field>
+        <field type="CharField" name="lyhenne"></field>
+        <field type="CharField" name="tehtavaryhma"></field>
+        <field type="CharField" name="tehtavaluokka"></field>
+        <field type="TextField" name="rastikasky"></field>
+        <field type="IntegerField" name="jarjestysnro">3</field>
+        <field type="CharField" name="kaava">ss</field>
+        <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">15</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
+        <field type="CharField" name="maksimipisteet">3</field>
+        <field type="BooleanField" name="svirhe">False</field>
+    </object>
+    <object pk="781" model="tupa.testaustulos">
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">101</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">181</field>
+        <field type="CharField" name="pisteet">0.5</field>
+    </object>
+    <object pk="782" model="tupa.testaustulos">
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">102</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">181</field>
+        <field type="CharField" name="pisteet">1.0</field>
+    </object>
+    <object pk="783" model="tupa.testaustulos">
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">103</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">181</field>
+        <field type="CharField" name="pisteet">0.5</field>
+    </object>
+    <object pk="503" model="tupa.syotemaarite">
+        <field type="CharField" name="nimi">a</field>
+        <field type="CharField" name="tyyppi">piste</field>
+        <field type="CharField" name="kali_vihje">testi</field>
+        <field to="tupa.osatehtava" name="osa_tehtava" rel="ManyToOneRel">345</field>
+    </object>
+    <object pk="3546" model="tupa.syote">
+        <field type="CharField" name="arvo">0.5</field>
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">101</field>
+        <field to="tupa.syotemaarite" name="maarite" rel="ManyToOneRel">503</field>
+        <field type="CharField" name="tarkistus">0.5</field>
+    </object>
+    <object pk="3547" model="tupa.syote">
+        <field type="CharField" name="arvo">1.0</field>
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">102</field>
+        <field to="tupa.syotemaarite" name="maarite" rel="ManyToOneRel">503</field>
+        <field type="CharField" name="tarkistus">1.0</field>
+    </object>
+    <object pk="3548" model="tupa.syote">
+        <field type="CharField" name="arvo">0.5</field>
+        <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">103</field>
+        <field to="tupa.syotemaarite" name="maarite" rel="ManyToOneRel">503</field>
+        <field type="CharField" name="tarkistus">0.5</field>
+    </object>
+    <object pk="345" model="tupa.osatehtava">
+        <field type="CharField" name="nimi">a</field>
+        <field type="CharField" name="tyyppi">kp</field>
+        <field type="CharField" name="kaava">a</field>
+        <field to="tupa.tehtava" name="tehtava" rel="ManyToOneRel">181</field>
+    </object>
+</django-objects>

--- a/web/fixtures/tests/tasapisteet.xml
+++ b/web/fixtures/tests/tasapisteet.xml
@@ -94,7 +94,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">12</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="103" model="tupa.syotemaarite">
         <field type="CharField" name="nimi">a</field>
@@ -152,7 +152,7 @@
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">12</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="104" model="tupa.syotemaarite">
         <field type="CharField" name="nimi">a</field>
@@ -210,7 +210,7 @@
         <field type="IntegerField" name="jarjestysnro">3</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">12</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="105" model="tupa.syotemaarite">
         <field type="CharField" name="nimi">a</field>

--- a/web/fixtures/tests/tehtavan_kaava.xml
+++ b/web/fixtures/tests/tehtavan_kaava.xml
@@ -79,7 +79,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">a+b</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">11</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="740" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">71</field>
@@ -198,7 +198,7 @@
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">a-b</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">11</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="745" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">71</field>
@@ -317,7 +317,7 @@
         <field type="IntegerField" name="jarjestysnro">3</field>
         <field type="CharField" name="kaava">a*b</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">11</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="750" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">71</field>
@@ -436,7 +436,7 @@
         <field type="IntegerField" name="jarjestysnro">4</field>
         <field type="CharField" name="kaava">a/b</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">11</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="755" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">71</field>

--- a/web/fixtures/tests/tehtavan_nimi_funktio.xml
+++ b/web/fixtures/tests/tehtavan_nimi_funktio.xml
@@ -35,7 +35,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">sum([0.5,0.5])</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">9</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="1446" model="tupa.testaustulos">
@@ -75,7 +75,7 @@
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">med([0,1,2])</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">9</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="1447" model="tupa.testaustulos">
@@ -115,7 +115,7 @@
         <field type="IntegerField" name="jarjestysnro">3</field>
         <field type="CharField" name="kaava">log(10)</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">9</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="1448" model="tupa.testaustulos">

--- a/web/fixtures/tests/tehtnum_muk.xml
+++ b/web/fixtures/tests/tehtnum_muk.xml
@@ -71,7 +71,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">34</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="2341" model="tupa.testaustulos">

--- a/web/fixtures/tests/tuomarineuvos_django_1_1.xml
+++ b/web/fixtures/tests/tuomarineuvos_django_1_1.xml
@@ -30,7 +30,7 @@
         <field name="jarjestysnro" type="IntegerField">1</field>
         <field name="kaava" type="CharField">ss</field>
         <field name="sarja" rel="ManyToOneRel" to="tupa.sarja">2</field>
-        <field name="tarkistettu" type="BooleanField">False</field>
+        <field name="tarkistettu" type="BooleanField">True</field>
     </object>
     <object model="tupa.syotemaarite" pk="26">
         <field name="nimi" type="CharField">a</field>

--- a/web/fixtures/tests/tyhja_mediaani.xml
+++ b/web/fixtures/tests/tyhja_mediaani.xml
@@ -71,7 +71,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">12</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet"></field>
     </object>
     <object pk="1461" model="tupa.testaustulos">

--- a/web/fixtures/tests/valivaiheet_ilman_vartiota.xml
+++ b/web/fixtures/tests/valivaiheet_ilman_vartiota.xml
@@ -24,7 +24,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">11</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
         <field type="CharField" name="maksimipisteet">1</field>
         <field type="BooleanField" name="svirhe">False</field>
     </object>

--- a/web/fixtures/tests/vapaakaava_vakio_operaatio_muuttuja.xml
+++ b/web/fixtures/tests/vapaakaava_vakio_operaatio_muuttuja.xml
@@ -79,7 +79,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="1" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -201,7 +201,7 @@
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="6" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -323,7 +323,7 @@
         <field type="IntegerField" name="jarjestysnro">3</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="11" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>
@@ -445,7 +445,7 @@
         <field type="IntegerField" name="jarjestysnro">4</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">1</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="16" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">1</field>

--- a/web/fixtures/tests/vapaan_jako_vakiolla.xml
+++ b/web/fixtures/tests/vapaan_jako_vakiolla.xml
@@ -79,7 +79,7 @@
         <field type="IntegerField" name="jarjestysnro">1</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="5" model="tupa.syotemaarite">
         <field type="CharField" name="nimi">a</field>
@@ -284,7 +284,7 @@
         <field type="IntegerField" name="jarjestysnro">2</field>
         <field type="CharField" name="kaava">ss</field>
         <field to="tupa.sarja" name="sarja" rel="ManyToOneRel">2</field>
-        <field type="BooleanField" name="tarkistettu">False</field>
+        <field type="BooleanField" name="tarkistettu">True</field>
     </object>
     <object pk="1" model="tupa.testaustulos">
         <field to="tupa.vartio" name="vartio" rel="ManyToOneRel">5</field>

--- a/web/tupa/TulosLaskin.py
+++ b/web/tupa/TulosLaskin.py
@@ -19,10 +19,10 @@ import log
 def korvaa(lause,pino,loppu=None) :
     """
     Korvaa lauseen muuttujat pinon mukaisella etuliitteella a.b.c jne.
-    "." lausessa muuttujan edessa liikuttaa muuttujaa pinossa ylospain 
-    optionaalinen loppu parametri lisaa muuttujan peraan arvon. 
+    "." lausessa muuttujan edessa liikuttaa muuttujaa pinossa ylospain
+    optionaalinen loppu parametri lisaa muuttujan peraan arvon.
     loppu parametri poistuu ensimmaisella .a operaatiola
-    esim: 
+    esim:
     >>> korvaa("c",["a","b"])
     'a.b.c'
     >>> korvaa(".c",["a","b"])
@@ -49,10 +49,10 @@ def korvaa(lause,pino,loppu=None) :
     '56'
     """
     # Ensiksi täytyy poistaa kaikki x..y -> y
-    poistoon= re.search(r"([^-.+*/(),]+[.][.])",lause) 
+    poistoon= re.search(r"([^-.+*/(),]+[.][.])",lause)
     while poistoon :
         lause=re.sub(r"([^-.+*/()]+[.][.])","",lause,count=1)
-        poistoon= re.search(r"([^-.+*/()]+[.][.])",lause) 
+        poistoon= re.search(r"([^-.+*/()]+[.][.])",lause)
     haku= re.finditer("(?<![]])(\.{0,3})([a-zA-Z]\w*)(?:\.(\w+))?(?:\.(\w+))?(?:\.(\w+))?(?!\w*[(])",lause )
     muutokset=[]
     for h in haku :
@@ -66,11 +66,11 @@ def korvaa(lause,pino,loppu=None) :
             for i in range(kohtaan) :
                 uusi=uusi+"." +pino[i]
             for g in ryhmat[1:] :
-                if g: 
+                if g:
                     uusi=uusi+"."+g
                     vanha=vanha+"."+g
             vanha=vanha[1:]
-            if loppu and len(ryhmat[0])==0: 
+            if loppu and len(ryhmat[0])==0:
                 uusi=uusi+"."+loppu
             uusi=uusi[1:]
             muutokset.append((h.start(),h.end(),uusi))
@@ -98,7 +98,7 @@ def suoritusJoukko(s) :
     return muokattu
 
 def luoMuuttujat(vartiot,tehtavat,syotteet) :
-    """ 
+    """
     Luo sarjan syotteiden muuttujasanakirjan:
     rakenne on muotoa: muuttujat[tehtavan_nimi][osatatehtavan_nimi][syotteen_nimi][vartion_nro]=arvo
     mukana olevien vartioista loytyy tieto: muuttujat[tehtavan_nimi]["mukana"][vartion_nro]=1
@@ -120,10 +120,10 @@ def luoMuuttujat(vartiot,tehtavat,syotteet) :
                 dict_syotteet=[]
                 for v in vartiot :
                     s=maaritteen_syotteet.filter(vartio=v)
-                    if len(s)==1 : 
+                    if len(s)==1 :
                         try :
                             dict_syotteet.append((str(v.nro),DictDecimal(s[0].arvo)))
-                        except InvalidOperation: 
+                        except InvalidOperation:
                             if not s[0].arvo=="kesk":
                                 dict_syotteet.append((str(v.nro),s[0].arvo))
                         except TypeError : pass
@@ -142,7 +142,7 @@ def luoOsatehtavanKaava(ot_lause,parametrit):
     -Toteuttaa muk -> ..mukana pikatien
     -Muuntaa suor pikatien kaikkien vartioiden suorituksiin parametristä vartion_kaava
     """
-    ot_lause #=ot.kaava #.lower() 
+    ot_lause #=ot.kaava #.lower()
     log.logString( "  kaava = " + ot_lause )
     korvautuu=True
 
@@ -156,7 +156,7 @@ def luoOsatehtavanKaava(ot_lause,parametrit):
         vanha=ot_lause
         for p_nimi,p_arvo in parametrit.items():
             ot_lause=re.sub(p_nimi+r"(?!\w+)",p_arvo,ot_lause)
-        # Pikatie "muk" -> "..mukana" 
+        # Pikatie "muk" -> "..mukana"
         ot_lause=re.sub("muk"+r"(?!\w+)","..mukana",ot_lause)
         # Muunnos "suor" -> kaikkien vartioiden lasketut suoritukset
         try:
@@ -171,19 +171,19 @@ def luoOsatehtavanKaava(ot_lause,parametrit):
     return ot_lause
 
 def luoTehtavanKaava(t,v):
-        pino=[] # Pinoon laitetaan kulloinenkin iterointipolku, 
+        pino=[] # Pinoon laitetaan kulloinenkin iterointipolku,
                 #jotta muuttujan nimet voidaan muuttaa suhteellisesta kirjaimesta absoluuttiseen polkuun.
         t_nimi= t.nimi.replace(" ","").replace("!","").lower()
         pino.append(t_nimi)
         osatehtavat=t.osatehtava_set.all()
         ot_lauseet=[]
-        
+
         log.logString( u"<h3>Tehtävä: " + t.nimi.upper()+"</h3>" )
         if t.kaava.upper()=="SS" :
                 log.logString( u"kaava = ⚡⚡" )
         else:
                 log.logString( u"kaava =  " + t.kaava.upper() )
-        
+
         for ot in osatehtavat:
                 log.logString( u"\n<b>Osatehtävä: " + ot.nimi.upper()+"</b>" )
                 pino.append(ot.nimi)
@@ -196,7 +196,7 @@ def luoTehtavanKaava(t,v):
                         for m in maaritteet:
                                 ot_lause=ot_lause+m.nimi+"+"
                         ot_lause=ot_lause[:-1]
-                
+
                 parametrit={}
                 for p in ot.parametri_set.all():
                         parametrit[p.nimi]=p.arvo
@@ -209,12 +209,12 @@ def luoTehtavanKaava(t,v):
                         if not ot_lause==vanha : korvautuu=True
 
                 log.logString( "  sijoitettu = " + ot_lause )
-                     
-                # Muutetaan muuttujien nimet koko polun mittaisiksi: 
+
+                # Muutetaan muuttujien nimet koko polun mittaisiksi:
                 #tehtava(nimi).osatehtava(nimi).syote(nimi).vartio(nro)
                 ot_lause=korvaa(ot_lause,pino,str(v.nro))
                 # Pikatie vartio -> vartion numero
-                ot_lause=re.sub("vartio"+r"(?!\w+)", str(v.nro) ,ot_lause)        
+                ot_lause=re.sub("vartio"+r"(?!\w+)", str(v.nro) ,ot_lause)
                 ot_lauseet.append((ot.nimi,ot_lause))
                 pino.pop()
         tehtava_lause=""
@@ -246,13 +246,13 @@ def luoLaskut(vartiot,tehtavat) :
 
 def laskeSarja(sarja,syotteet,vartiot=None,tehtavat=None):
         """
-        Laskee tulokset halutulle sarjalle. 
+        Laskee tulokset halutulle sarjalle.
         Palauttaa kaksiuloitteisen taulukon[vartio][tehtävä] = pisteet.
         Taulukon ensimmäisissä sarakkeissa on vartio tai tehtävä objekteja muissa pisteitä.
         Taulukon vasemmassa ylänurkassa on sarjan objekti
         """
         #syotteetr=Syote.objects.all() #(maarite__osa_tehtava__tehtava__sarja=sarja )
-        
+
         if not vartiot : vartiot=sarja.vartio_set.all()
         if not tehtavat: tehtavat=sarja.tehtava_set.all()
         if vartiot and tehtavat : jee=1 # Pakotetaan tietokantahaku.
@@ -274,12 +274,16 @@ def laskeSarja(sarja,syotteet,vartiot=None,tehtavat=None):
                         for s in tehtSyotteet :
                                 if s.arvo=="e" : tekematta=True
                                 if not s.arvo=="h":  hylatty=False
-                        
+
                         if hylatty and len(tehtSyotteet): tulokset[i][t]= "H"
                         if tekematta: tulokset[i][t]= "E"
 
+                # Lasketaan vain tehtävät, jotka on merkitty "tarkistettu" -checkboxilla
+                for t in range(len(tulokset[i])) :
+                        if not tehtavat[t].tarkistettu: tulokset[i][t] = "S"
+
                 #Merkataan siirrettäviksi ulkopuolella olevat:
-                if not vartiot[i].keskeyttanyt == None or not vartiot[i].ulkopuolella == None : 
+                if not vartiot[i].keskeyttanyt == None or not vartiot[i].ulkopuolella == None :
                         #Merkataan keskeyttaneille tuloksiin "K" keskeyttämisestä eteenpäin
                         if not vartiot[i].keskeyttanyt==None:
                                 kesk=vartiot[i].keskeyttanyt-1
@@ -292,18 +296,18 @@ def laskeSarja(sarja,syotteet,vartiot=None,tehtavat=None):
                                 tuom=vartion_tuomarit.filter(tehtava=tehtavat[t])
                                 if len(tuom) :
                                         log.logString( u"Tuomarineuvoston ylimääritys: " + str(tuom[0].pisteet) )
-                                        try: 
+                                        try:
                                                 tulokset[i][t]= Decimal(tuom[0].pisteet)
                                         except:
                                                 tulokset[i][t]= tuom[0].pisteet
                 #Kokonaispisteet:
                 summa=0
                 for s in tulokset[i] :
-                        if s and type(s)!=str and type(s)!=unicode : summa+= s 
+                        if s and type(s)!=str and type(s)!=unicode : summa+= s
                 tulokset[i].insert(0,summa)
                 #Vartio objekti jokaisen rivin alkuun:
                 tulokset[i].insert(0,vartiot[i])
-        
+
         # Kirjataan välivaiheisiin lopputulos
         try:
                 log.logString( "\n<b>TULOS = " + str(tulokset[0][2])+"</b>" )
@@ -336,7 +340,7 @@ def laskeSarja(sarja,syotteet,vartiot=None,tehtavat=None):
         if sarja.tasapiste_teht1 : tasa1 = sarja.tasapiste_teht1+1
         if sarja.tasapiste_teht2 : tasa2 = sarja.tasapiste_teht2+1
         if sarja.tasapiste_teht2 : tasa3 = sarja.tasapiste_teht3+1
-        
+
         tulokset.sort(key=operator.itemgetter(1) ,reverse=True)
         ulkona.sort(key=operator.itemgetter(1) ,reverse=True)
         #Järjestetään taulukot
@@ -345,7 +349,7 @@ def laskeSarja(sarja,syotteet,vartiot=None,tehtavat=None):
                 ulkona.sort( key=operator.itemgetter(1,tasa1,tasa2,tasa3),reverse=True )
         except : # tehtäviä < 3
 		        pass
-        
+
         # Etsitään tasapistetulokset :
         edellinen=None
         for vi, vartio in enumerate(ulkona) :
@@ -363,7 +367,7 @@ def laskeSarja(sarja,syotteet,vartiot=None,tehtavat=None):
                 edellinen = vartio
         #Lisätään tehtävärivi ylos
         mukana.insert(0,t_list)
-        
+
         return (mukana,ulkona)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Tulostoimistossa on usein tarve piilottaa syötettyjä tuloksia, jos tiedetään niihin liittyvän epäselvyyksiä. Syynä voi olla esimerkiksi kaavavirhe, jota ei ole vielä selvitetty, tai yksinkertaisesti se, että tehtävästä on syötetty vasta puolet (esim. yökätevyyden aloitus- ja palautusajat syötetty, mutta varsinaiset pisteet puuttuvat vielä – varsin yleinen skenaario). Tällöin olisi hyvä, että tulosluettelossa ei näy keskeneräisiä tuloksia, vaan tulospäällikkö voisi hallita tulosten näyttämistä.

Tulosten syöttönäkymässä on entuudestaan tarkistettu-checkbox, jonka voi tallentaa, mutta jolla en ole havainnut olevan mitään vaikutusta mihinkään muualla.

![Screenshot 2021-10-05 at 8 50 27](https://user-images.githubusercontent.com/1097009/135967974-9da19884-610c-40ce-9f92-73db471c59a4.png)

Ehdotan ratkaisua, että tulosluettelossa näytetään vain tehtävät, jotka on tarkistettu. Muutokset riveillä 281-283.

