### PR TITLE
Salli https-protokolla tehtäväkäskylinkeissä

### DIFF
--- a/web/tupa/TehtavanMaaritys.py
+++ b/web/tupa/TehtavanMaaritys.py
@@ -730,18 +730,18 @@ def tehtavanMaaritysForm(posti,data,sarja_id,suurin_jarjestysnro=0,prefix="tehta
                                                 errors="Anna merkkijono!"
                                                 data['valid']=False
                                 if fk=='rastikasky' :                        #Estetään muiden kuin validien osotteiden syöttö
-                                        if value and not value.startswith('http://'):
-                                                errors="Osoitteen alettava 'http://' !"
+                                        if value and not (value.startswith('http://') or value.startswith('https://')):
+                                                errors="Osoitteen alettava 'http://' tai 'https://'"
                                                 data['valid']=False
-                
+
                                 # Kaavan validiointi:
                                 if  fk=='kaava' :
                                         if not is_kaava(value):
                                                 errors="Kaava ei toimi!"
-                                                data['valid']=False                                
+                                                data['valid']=False
 
                         if not fk== 'osa_tehtavat' :  formidata.append( (fk,{'id' : id,
-                                                        'name' : id , 
+                                                        'name' : id ,
                                                         'value' : value,
                                                         'errors' : errors } ) )
                         data[k][fk]=value


### PR DESCRIPTION
2020-luku soitti ja pyysi päivittämään sallitut protokollat.

Tehtäväkäskylinkkiin pystyi aiemmin laittamaan vain `http://`-alkuisia linkkejä, nyt lisätty myös `https://`.