### PR TITLE
Add allowed hosts setting

### DIFF
--- a/web/settings/__init__.py
+++ b/web/settings/__init__.py
@@ -2,6 +2,8 @@ import os
 
 hakemisto=os.path.normpath(os.path.dirname(__file__)) + '/..'
 
+ALLOWED_HOSTS = ['localhost', '127.0.0.1']
+
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 RECORDING = False


### PR DESCRIPTION
Tälläinen asetus tosiaan pitäis olla kun pelataan Django 1.5:n kanssa.
Dokumentaatio: https://docs.djangoproject.com/en/4.2/releases/1.5/#allowed-hosts-required-in-production

Jos tää pitäis asettaa jollain muulla tavalla niin saa ehdottaa.

Mikäli tuota ei ollut asetettu niin palvelu oireili:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/wsgiref/handlers.py", line 86, in run
    self.finish_response()
  File "/usr/lib/python2.7/wsgiref/handlers.py", line 128, in finish_response
    self.write(data)
  File "/usr/lib/python2.7/wsgiref/handlers.py", line 217, in write
    self._write(data)
  File "/usr/lib/python2.7/socket.py", line 328, in write
    self.flush()
  File "/usr/lib/python2.7/socket.py", line 307, in flush
    self._sock.sendall(view[write_offset:write_offset+buffer_size])
error: [Errno 32] Broken pipe
Traceback (most recent call last):
  File "/usr/lib/python2.7/SocketServer.py", line 599, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python2.7/SocketServer.py", line 334, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/local/lib/python2.7/site-packages/django/core/servers/basehttp.py", line 150, in __init__
    super(WSGIRequestHandler, self).__init__(*args, **kwargs)
  File "/usr/lib/python2.7/SocketServer.py", line 657, in __init__
    self.finish()
  File "/usr/lib/python2.7/SocketServer.py", line 716, in finish
    self.wfile.close()
  File "/usr/lib/python2.7/socket.py", line 283, in close
    self.flush()
  File "/usr/lib/python2.7/socket.py", line 307, in flush
    self._sock.sendall(view[write_offset:write_offset+buffer_size])
error: [Errno 32] Broken pipe
```