### PR TITLE
Testien ajaminen Djangon versiossa 1.5

### DIFF
--- a/web/settings/__init__.py
+++ b/web/settings/__init__.py
@@ -108,7 +108,7 @@ INSTALLED_APPS = [
 LOGIN_URL = ('/kipa/')
 LOGIN_REDIRECT_URL = ('/kipa/')
 
-TEST_RUNNER = ('tupa.tests')
+TEST_RUNNER = ('tupa.tests.CustomTestRunner')
 
 # Should we serve the media files through Python?
 SERVE_MEDIA = DEBUG

--- a/web/tupa/tests.py
+++ b/web/tupa/tests.py
@@ -8,6 +8,7 @@ from models import *
 from taulukkolaskin import *
 import decimal
 from django.test import TestCase
+from django.test.simple import DjangoTestSuiteRunner
 from views import *
 import os
 from django.test.client import Client
@@ -307,6 +308,10 @@ class TasapisteTesti(TestCase) :
                 assert tulokset[0][5][0].nro==5
                 assert tulokset[0][6][0].nro==6
 
+class CustomTestRunner(DjangoTestSuiteRunner):
+        def run_tests(self, test_labels=None, extra_tests=None, verbosity=1, interactive=True, failfast=True, **kwargs):
+                run_one_fixture(test_labels, verbosity, interactive, extra_tests)
+
 def run_one_fixture(test_labels, verbosity=1, interactive=True, extra_tests=[]):
 #ajetaan vain haluttu fixtuuri
 # Nollataan fixturet
@@ -401,7 +406,7 @@ def run_one_fixture(test_labels, verbosity=1, interactive=True, extra_tests=[]):
         suites.append(unittest.TestLoader().loadTestsFromTestCase(t))
     suite=unittest.TestSuite(suites)
 
-    old_name = settings.DATABASE_NAME
+    old_name = settings.DATABASES["default"]["NAME"]
     from django.db import connection
     connection.creation.create_test_db(verbosity, autoclobber=not interactive)
     result = unittest.TextTestRunner(verbosity=verbosity).run(suite)


### PR DESCRIPTION
Lisäilin tuollaisen DjangoTestSuiteRunnerista periytetyn wrapperin, että saadaan testit ajettua.

Jossain kohtaa myöhemmin vois varmaan ottaa ton wrapperin tosta välistä pois yksinkertaisuuden nimissä. Näin saadaan kuitenkin nyt pienempi diffi ja vältytään tarpeelta korjatat tuon run_one_fixture:n sisennys.