### PR TITLE
Django 1.6

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -136,30 +136,12 @@ Vieraile tupa2.sf.net Imagen linkkiä varten.
 
 ### Muut käyttöjärjestelmät / itse muokattava asennus
 
-Mikäli koneella on esimerkiksi Apache pyörittämässä jotain muuta
-sovellusta, haluaa käyttää jotain toista http palvelinta tai
-käyttöjärjestelmää on tässä kuvattu mitä tarvitaan Kipan asentamiseen ja
-pyörittämiseen.
-
-Kipaa ei missään tapauksessa kannata asentaa automaattipaketeilla
-tietokoneelle missä on jo Apache asennettuna!
-
 Kipan laskenta perustuu Pythonin-ohjelmointikielellä kirjoitettuun koodiin.
-Python 2.5-2.6 on testattu ja tuettu.
+Python 2.7 on testattu.
 
-Kipan web-julkaisu ja kantayhteydet djangoon. Djangon versiot 1.0 sekä
-1.1 on testattu (nämä ovat melko nirsoja tod. näk. uusiin versioihin)
+Djangon versio 1.6 on testattu kehityspalvelimen kanssa toimivaksi.
 
-Koneelle pitää asentaa http-palvelin joka osaa suorittaa python koodia
-esimerkiksi modpython moduulin avulla ja lisäksi tarjota djangolle oma
-"hakemisto", jossa se toimii. Tässä kannattaa tutustua Kipaa varten
-muokattuun httpd.conf tiedostoon
-([www.tupa2.sf.net](http://www.tupa2.sf.net)).
-
-Web-tiedostot kopioidaan samaan hakemistoon, johon on määritelty Djangon
-oma hakemisto
-
-Asennus niille jotka luulee tietävänsä mitä tekee tai haluaa ymmärtää.
+Apache-asennus ei toimi kehitysversiossa.
 
 ### Asennuksen poistaminen
 
@@ -677,11 +659,7 @@ ei kuitenkaan ole nähty olevan vaikutusta suorituskykyyn.
 
 ### Testattuja käyttöjärjestelmiä ja komponentteja
 
-* Windows 7 32bit/64bit, Windows Vista 32bit
-* Ubuntu 8.10, 9.04, 9.10, Debian 5, Arch Linux
-* Python 2.5, Python 2.6
-* Django 1.0 & 1.1
-* Apache 2.2
+Kehitysversiota ei ole testattu kattavasti millään käyttöjärjestelmällä.
 
 ## Lisenssi
 
@@ -745,20 +723,9 @@ jatkokehityksestä löytyy.
 
 ## Apachen konfigurointi
 
-Apachen httpd.conf-tiedostoon pitää lisätä seuraava tekstinpätkä, jotta
-voidaan ajaa Python-koodia sekä djangoa. Alla oleva konfiguraatio
-edellyttää että tiedostot ovat kopioitu hakemistoon /data (Linux/Unix)
-tietokoneilla.
-
-```
-<Location "/kipa/">
-    SetHandler python-program
-    PythonHandler django.core.handlers.modpython
-    SetEnv DJANGO_SETTINGS_MODULE web.settings
-    PythonDebug On
-    PythonPath "['/data'] + sys.path"
-</Location>
-```
+Kipaa on käytetty Apachen kanssa moduulilla mod-python. Djangon tuki
+mod-pythonille on kuitenkin loppunut jo versiossa 1.5. Kehitysversion
+käyttö Apachen kanssa ei ole siis tällä hetkellä ole tuettu.
 
 ## Kaavat
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==1.5
+django==1.6
 south
 #mysql-python
 git+https://github.com/PyMySQL/mysqlclient-python.git@v1.4.6#egg=MySQLdb

--- a/web/manage.py
+++ b/web/manage.py
@@ -1,20 +1,10 @@
 #!/usr/bin/python2
 
+import os
 import sys
 
-print sys.path
-from django.core.management import execute_manager
-
-try:
-    import settings  #
-except ImportError:
-    import sys
-
-    sys.stderr.write(
-        "Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n"
-        % __file__
-    )
-    sys.exit(1)
+from django.core.management import execute_from_command_line
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+    execute_from_command_line(sys.argv)

--- a/web/settings/__init__.py
+++ b/web/settings/__init__.py
@@ -107,7 +107,6 @@ INSTALLED_APPS = [
     "django.contrib.admin",
     #'django.contrib.formtools',
     "django.template",
-    "django.contrib.databrowse",
 ]
 
 LOGIN_URL = "/kipa/"

--- a/web/tupa/models.py
+++ b/web/tupa/models.py
@@ -30,7 +30,7 @@ class Kisa(models.Model):
     nimi = models.CharField(max_length=255)
     aika = models.CharField(max_length=255, blank=True, null=True)
     paikka = models.CharField(max_length=255, blank=True)
-    tunnistus = models.BooleanField()
+    tunnistus = models.BooleanField(default=False)
 
     def __unicode__(self):
         return self.nimi
@@ -159,9 +159,9 @@ class Tehtava(models.Model):
     jarjestysnro = models.IntegerField()
     kaava = models.CharField(max_length=255)
     sarja = models.ForeignKey(Sarja)
-    tarkistettu = models.BooleanField()
+    tarkistettu = models.BooleanField(default=False)
     maksimipisteet = models.CharField(max_length=255)
-    svirhe = models.BooleanField()
+    svirhe = models.BooleanField(default=False)
 
     def mukanaOlevatVartiot(self):
         """

--- a/web/tupa/tests.py
+++ b/web/tupa/tests.py
@@ -8,7 +8,7 @@ from models import *
 from taulukkolaskin import *
 import decimal
 from django.test import TestCase
-from django.test.simple import DjangoTestSuiteRunner
+from django.test.runner import DiscoverRunner
 from views import *
 import os
 from django.test.client import Client
@@ -378,7 +378,7 @@ class TasapisteTesti(TestCase):
         assert tulokset[0][6][0].nro == 6
 
 
-class CustomTestRunner(DjangoTestSuiteRunner):
+class CustomTestRunner(DiscoverRunner):
     def run_tests(
         self,
         test_labels=None,

--- a/web/tupa/urls.py
+++ b/web/tupa/urls.py
@@ -2,7 +2,7 @@
 # KiPa(KisaPalvelu), tuloslaskentajärjestelmä partiotaitokilpailuihin
 #    Copyright (C) 2010  Espoon Partiotuki ry. ept@partio.fi
 
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns
 from models import *
 from django.conf import settings
 

--- a/web/tupa/views.py
+++ b/web/tupa/views.py
@@ -794,7 +794,7 @@ def sarjanTuloksetCSV(request, kisa_nimi, sarja_id):
     ulkona = tulokset[1]
     numero = 1
     # Luodaan HttpResponse-objekti CSV-headerillä.
-    response = HttpResponse(mimetype="text/csv")
+    response = HttpResponse(content_type="text/csv")
 
     disposition = "attachment; filename=" + kisa_nimi + "_" + sarja.nimi + ".csv"
     response["Content-Disposition"] = disposition.encode("utf-8")
@@ -944,7 +944,7 @@ def tallennaKisa(request, kisa_nimi):
     """
     kisa = get_object_or_404(Kisa, nimi=kisa_nimi)
 
-    response = HttpResponse(kisa_xml(kisa), mimetype="application/xml")
+    response = HttpResponse(kisa_xml(kisa), content_type="application/xml")
     response["Content-Disposition"] = "attachment; filename=tietokanta.xml"
     return response
 
@@ -1131,7 +1131,7 @@ def post_txt(request, parametrit):
 
     response = HttpResponse(
         doc.toprettyxml(indent="  "),
-        mimetype="application/xml",
+        content_type="application/xml",
         context_instance=RequestContext(request),
     )
     response["Content-Disposition"] = "attachment; filename=tietokanta.xml"

--- a/web/urls.py
+++ b/web/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import include, patterns
 from django.contrib import admin
 from django.conf import settings
 


### PR DESCRIPTION
Django 1.6 on sillä tavalla merkityksellinen rajapyykki, että se on ollut ensimmäinen Python 3:sta tukenut Django. Eli tämän jälkeen päästään tekemään python-version korotusta.

Tässä PR:ssä minkään toiminnallisuuden ei pitäisi muuttua.

Katselmointia @vaaralav tai @ZeiP?