### PR TITLE
Return non-zero status for failing unit tests

### DIFF
--- a/web/tupa/tests.py
+++ b/web/tupa/tests.py
@@ -388,7 +388,7 @@ class CustomTestRunner(DjangoTestSuiteRunner):
         failfast=True,
         **kwargs
     ):
-        run_one_fixture(test_labels, verbosity, interactive, extra_tests)
+        return run_one_fixture(test_labels, verbosity, interactive, extra_tests)
 
 
 def run_one_fixture(test_labels, verbosity=1, interactive=True, extra_tests=[]):


### PR DESCRIPTION
This have been broken since fa0da99b622da18985ad34e229099a922eb4010d.