### PR TITLE
Django-templaattien formatointi

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,6 @@ ae6391ac34b6f959fd16053f24076353aae0e54b
 
 # Format python code with black
 b215abbc7ae11614bab50fb7c3b95c307cf933d5
+
+# Format Django templates with djLint
+047d51f497bdb08d6c092b05d917d331fb7cebd0

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,10 +16,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install 'black==24.10.0'
+          pip install 'djlint==1.36.3'
       - name: Check formatting
         run: |
           black -t py312 --check .
           black -t py312 --check web/**/*.py.example
+          djlint --check .
   unit-tests-sqlite:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/docs/development.md
+++ b/docs/development.md
@@ -72,11 +72,15 @@ Hakemistosta `./web/roobt` löytyy myös toinen robot-tiedosto nimeltään
 `autentikointi.txt`, mutta sen ajaminen ei taida onnistua, ellei ensin
 toteuta Kipaan suunniteltua kirjautumista.
 
-## Python-koodin formatointi
+## Python-koodin ja Django-templaattien formatointi
 
 Koodi noudattaa Black-autoformatterin vesion 24.10.0 mukaista tyyliä.
-Blackille annetaan lippu `--target-version py312`. Formatointi tarkastetaan
-osana CI-putkea.
+Blackille annetaan lippu `--target-version py312`. Templaatit formatoidaan
+käyttäen [djLint:tiä](https://www.djlint.com/), joka ajetaan seuraavasti:
+`djlint --reformat --profile=django .`. Toisin kuin Black, djLint ei takaa
+tiedostojen ehjänä pysymistä, joten muutosten tarkastaminen manuaalisesti
+formatoinnin jälkeen voi olla tarpeen. Formatoinnit tarkastetaan osana
+CI-putkea.
 
 ## Selityksiä lähdekooditiedostoista
 

--- a/web/robot/yhteiset_resurssit.resource
+++ b/web/robot/yhteiset_resurssit.resource
@@ -30,7 +30,7 @@ Kipa Suite Setup
 
 Open Sub Page Verify Location And Title
     [Arguments]    ${link_name}    ${link}    ${page_title}
-    Click Link    ${link_name}
+    Click Link    xpath://a[contains(., '${link_name}')]
     Wait Until Keyword Succeeds    10 sec    2 sec    Location Should Be    ${KIPA_URL}/${TESTIKISA}/${link}/
     Wait Until Keyword Succeeds    10 sec    2 sec    Title Should Be    ${page_title}
 
@@ -46,7 +46,7 @@ Remove Competition
     Open KiPa Main Page
     click link    ${competition}
     title should be    Kipa - ${competition}
-    Click Link    poista kisa
+    Click Link    xpath://a[contains(., 'poista kisa')]
     Title Should Be    ${KISAN_POISTO_OTSIKKO}
     Click Button    Kyllä
     Wait Until Keyword Succeeds    10 sec    2 sec    Title Should Be    ${KAIKKI_KISAT_OTSIKKO}

--- a/web/templates/404.html
+++ b/web/templates/404.html
@@ -1,9 +1,7 @@
 <html>
-<head>
-
-</head>
-<body>
-<h1> 404 Sivua ei löydy </h1>
-<a href='/kipa/'>alkuun</a>
-</body>
+    <head></head>
+    <body>
+        <h1>404 Sivua ei löydy</h1>
+        <a href='/kipa/'>alkuun</a>
+    </body>
 </html>

--- a/web/templates/500.html
+++ b/web/templates/500.html
@@ -5,11 +5,13 @@
 <body bgcolor="black">
 <p>
 <br><br>
-<font color=red size=5><b>
-<h1>ERROR 500</h1>
-Ohjelmistovirhe . Paina <a href='/kipa/'>alkuun</a> jatkaaksesi.<br><br>
-Kyborgin kahvimuki : {{error}}
-</b></font>
+<font color=red size=5>
+    <b>
+        <h1>ERROR 500</h1>
+        Ohjelmistovirhe . Paina <a href='/kipa/'>alkuun</a> jatkaaksesi.<br><br>
+        Kyborgin kahvimuki : {{error}}
+    </b>
+</font>
 </p>
 </body>
 </html>

--- a/web/templates/500.html
+++ b/web/templates/500.html
@@ -1,19 +1,18 @@
 <html>
-<head>
-
-</head>
-<body bgcolor="black">
-<p>
-<br><br>
-<font color=red size=5>
-    <b>
-        <h1>ERROR 500</h1>
-        Ohjelmistovirhe . Paina <a href='/kipa/'>alkuun</a> jatkaaksesi.<br><br>
-        Kyborgin kahvimuki : {{error}}
-    </b>
-</font>
-</p>
-</body>
+    <head></head>
+    <body bgcolor="black">
+        <p>
+            <br>
+            <br>
+            <font color=red size=5>
+                <b>
+                    <h1>ERROR 500</h1>
+                    Ohjelmistovirhe . Paina <a href='/kipa/'>alkuun</a> jatkaaksesi.
+                    <br>
+                    <br>
+                    Kyborgin kahvimuki : {{ error }}
+                </b>
+            </font>
+        </p>
+    </body>
 </html>
-
-

--- a/web/templates/admin/base_site.html
+++ b/web/templates/admin/base_site.html
@@ -1,10 +1,9 @@
 {% extends "admin/base.html" %}
 {% load i18n %}
-
-{% block title %}{{ title }} | {% trans 'Django site admin' %}{% endblock %}
-
-{% block branding %}
-<h1 id="site-name">{% trans 'Django administration' %}</h1>
+{% block title %}
+    {{ title }} | {% trans 'Django site admin' %}
 {% endblock %}
-
+{% block branding %}
+    <h1 id="site-name">{% trans 'Django administration' %}</h1>
+{% endblock %}
 {% block nav-global %}{% endblock %}

--- a/web/templates/tupa/base.html
+++ b/web/templates/tupa/base.html
@@ -52,7 +52,7 @@ document.getElementById(id).style.display = visibility;
             {% include "tupa/login.html" %}
         </div>
 
-    </div><!-- /header -->
+    </div>
     <div id="breadcrumbs">
         {% if tarkistus %}
         <a href="/kipa/{{kisa_nimi}}/" class="capitalize">{{kisa_nimi|alaviiva_pois}}</a> {%if taakse.url and taakse.title%}» <a href="{{taakse.url}}tarkistus/">{{taakse.title|alaviiva_pois}} (tarkistus)</a> {% endif %}» {{heading|alaviiva_pois}}
@@ -77,7 +77,7 @@ document.getElementById(id).style.display = visibility;
                     <a href="/kipa/{{kisa_nimi}}/maarita/tehtava/" class="sitetoolbarnav" title="Määrittele tehtävät"><img src="/kipamedia/edit_page.png" width="32" height="32" alt="Määrittele tehtävät" /></a>
                     <a href="/kipamedia/Manuaali_v03.pdf" class="sitetoolbarnav" title="Apua"><img src="/kipamedia/help.png" width="32" height="32" alt="Apua" /></a>
                 </div>
-            </div><!-- /left -->
+            </div>
 
             <div id="right" class="column">
 
@@ -100,13 +100,13 @@ document.getElementById(id).style.display = visibility;
                         </script>
                 {% endif %}
 
-            </div><!-- /right -->
+            </div>
 
-        </div><!-- /container -->
+        </div>
 
-    </div><!-- /main -->
+    </div>
 
-</div><!-- /wrap -->
+</div>
 
 </body>
 

--- a/web/templates/tupa/base.html
+++ b/web/templates/tupa/base.html
@@ -1,113 +1,159 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE" />
-<title>Kipa - {% block title %}  {% endblock %}</title>
-<link rel="stylesheet" type="text/css" href="/kipamedia/kipa.css" />
-<link rel="stylesheet" type="text/css" href="/kipamedia/tabcontent.css" />
-<link rel="stylesheet" type="text/css" href="/kipamedia/jquery.jgrowl.css" />
-<link rel="icon" type="image/x-icon" href="/kipamedia/favicon.ico" />
-
-<script type="text/javascript" language="javascript" src="/kipamedia/jquery-1.4.2.min.js"></script>
-<script type="text/javascript" language="javascript" src="/kipamedia/jquery.jgrowl_minimized.js"></script>
-<script type="text/javascript" language="javascript" src="/kipamedia/tooltip.js"></script>
-<script type="text/javascript" src="/kipamedia/tabcontent.js">
-/***********************************************
-* Tab Content script v2.2- © Dynamic Drive DHTML code library (www.dynamicdrive.com)
-* This notice MUST stay intact for legal use
-* Visit Dynamic Drive at http://www.dynamicdrive.com/ for full source code
-***********************************************/
-</script>
-
-{% load kipatags %}
-{% block header %}  {% endblock %}
-
-<script language="JavaScript">
+    <head>
+        <meta http-equiv="Content-Type"
+              content="text/html; charset=utf-8"
+              HTTP-EQUIV="PRAGMA"
+              CONTENT="NO-CACHE" />
+        <title>Kipa -
+            {% block title %}{% endblock %}
+        </title>
+        <link rel="stylesheet" type="text/css" href="/kipamedia/kipa.css" />
+        <link rel="stylesheet" type="text/css" href="/kipamedia/tabcontent.css" />
+        <link rel="stylesheet" type="text/css" href="/kipamedia/jquery.jgrowl.css" />
+        <link rel="icon" type="image/x-icon" href="/kipamedia/favicon.ico" />
+        <script type="text/javascript"
+                language="javascript"
+                src="/kipamedia/jquery-1.4.2.min.js"></script>
+        <script type="text/javascript"
+                language="javascript"
+                src="/kipamedia/jquery.jgrowl_minimized.js"></script>
+        <script type="text/javascript"
+                language="javascript"
+                src="/kipamedia/tooltip.js"></script>
+        <script type="text/javascript" src="/kipamedia/tabcontent.js">
+            /***********************************************
+            * Tab Content script v2.2- © Dynamic Drive DHTML code library (www.dynamicdrive.com)
+            * This notice MUST stay intact for legal use
+            * Visit Dynamic Drive at http://www.dynamicdrive.com/ for full source code
+            ***********************************************/
+        </script>
+        {% load kipatags %}
+        {% block header %}{% endblock %}
+        <script language="JavaScript">
 function setVisibility(id, visibility) {
 document.getElementById(id).style.display = visibility;
 }
-</script>
-{% if talletettu %}
-<script type="text/javascript">
-   $.jGrowl.defaults.position = 'center';
-</script>
-    <script type="text/javascript">
+        </script>
+        {% if talletettu %}
+            <script type="text/javascript">$.jGrowl.defaults.position = 'center';</script>
+            <script type="text/javascript">
         $(document).ready(function() {
             $.jGrowl('{{talletettu}}', {
                 life: 3000
                 });
         });
-    </script>
-{% endif %}
-
-</head>
-
-<body>
-
-{% include "tupa/vaara_tietokanta.html" %}
-
-<div id="wrap">
-
-    <div id="header"><div id="pageTitle" class="capitalize"><a href="/kipa/{{kisa_nimi}}/">{{kisa_nimi|alaviiva_pois}}</a></div>
-        <div style="float:right; margin-top:-4px; margin-bottom:0; padding-bottom:0; height:18px;">
-            {% include "tupa/login.html" %}
-        </div>
-
-    </div>
-    <div id="breadcrumbs">
-        {% if tarkistus %}
-        <a href="/kipa/{{kisa_nimi}}/" class="capitalize">{{kisa_nimi|alaviiva_pois}}</a> {%if taakse.url and taakse.title%}» <a href="{{taakse.url}}tarkistus/">{{taakse.title|alaviiva_pois}} (tarkistus)</a> {% endif %}» {{heading|alaviiva_pois}}
-        {% else %}
-        <a href="/kipa/{{kisa_nimi}}/" class="capitalize">{{kisa_nimi|alaviiva_pois}}</a> {%if taakse.url and taakse.title%}» <a href="{{taakse.url}}">{{taakse.title|alaviiva_pois}}</a> {% endif %}» {{heading|alaviiva_pois}}
+            </script>
         {% endif %}
-
-    </div>
-
-    <div id="main" class="clearfix">
-
-        <div id="container">
-
-            <div id="left" class="column">
-                <div id="sitetoolbarrow">
-                    <a href="/kipa/{{kisa_nimi}}/" class="sitetoolbarnav" title="Etusivulle"><img src="/kipamedia/home.png" width="32" height="32" alt="Etusivulle" /></a>
-                    <a href="/kipa/{{kisa_nimi}}/syota/" class="sitetoolbarnav" title="Syötä suorituksia"><img src="/kipamedia/add.png" width="32" height="32" alt="Syötä suorituksia" /></a>
-                    <a href="/kipa/{{kisa_nimi}}/syota/tarkistus/" class="sitetoolbarnav" title="Syötä suorituksia (tarkistus)"><img src="/kipamedia/accept.png" width="32" height="32" alt="Syötä suorituksia (tarkistus)" /></a>
-                    <a href="/kipa/{{kisa_nimi}}/tulosta/normaali/" class="sitetoolbarnav" title="Tulokset"><img src="/kipamedia/chart.png" width="32" height="32" alt="Tulokset" /></a>
-                    <a href="/kipa/{{kisa_nimi}}/tulosta/tilanne/" class="sitetoolbarnav" title="Laskennan tilanne"><img src="/kipamedia/chart_up.png" width="32" height="32" alt="Laskennan tilanne" /></a>
-                    <a href="/kipa/{{kisa_nimi}}/maarita/vartiot/" class="sitetoolbarnav" title="Määrittele vartiot"><img src="/kipamedia/edit_profile.png" width="32" height="32" alt="Määrittele vartiot" /></a>
-                    <a href="/kipa/{{kisa_nimi}}/maarita/tehtava/" class="sitetoolbarnav" title="Määrittele tehtävät"><img src="/kipamedia/edit_page.png" width="32" height="32" alt="Määrittele tehtävät" /></a>
-                    <a href="/kipamedia/Manuaali_v03.pdf" class="sitetoolbarnav" title="Apua"><img src="/kipamedia/help.png" width="32" height="32" alt="Apua" /></a>
+    </head>
+    <body>
+        {% include "tupa/vaara_tietokanta.html" %}
+        <div id="wrap">
+            <div id="header">
+                <div id="pageTitle" class="capitalize">
+                    <a href="/kipa/{{ kisa_nimi }}/">{{ kisa_nimi|alaviiva_pois }}</a>
                 </div>
+                <div style="float:right;
+                            margin-top:-4px;
+                            margin-bottom:0;
+                            padding-bottom:0;
+                            height:18px">{% include "tupa/login.html" %}</div>
             </div>
-
-            <div id="right" class="column">
-
-                {% block content %}{% endblock %}
-                {% if tabs %}
-                        {% for tab in tabs %}
+            <div id="breadcrumbs">
+                {% if tarkistus %}
+                    <a href="/kipa/{{ kisa_nimi }}/" class="capitalize">{{ kisa_nimi|alaviiva_pois }}</a>
+                    {% if taakse.url and taakse.title %}
+                        » <a href="{{ taakse.url }}tarkistus/">{{ taakse.title|alaviiva_pois }} (tarkistus)</a>
+                    {% endif %}
+                    » {{ heading|alaviiva_pois }}
+                {% else %}
+                    <a href="/kipa/{{ kisa_nimi }}/" class="capitalize">{{ kisa_nimi|alaviiva_pois }}</a>
+                    {% if taakse.url and taakse.title %}» <a href="{{ taakse.url }}">{{ taakse.title|alaviiva_pois }}</a>{% endif %}
+                    » {{ heading|alaviiva_pois }}
+                {% endif %}
+            </div>
+            <div id="main" class="clearfix">
+                <div id="container">
+                    <div id="left" class="column">
+                        <div id="sitetoolbarrow">
+                            <a href="/kipa/{{ kisa_nimi }}/"
+                               class="sitetoolbarnav"
+                               title="Etusivulle">
+                                <img src="/kipamedia/home.png" width="32" height="32" alt="Etusivulle" />
+                            </a>
+                            <a href="/kipa/{{ kisa_nimi }}/syota/"
+                               class="sitetoolbarnav"
+                               title="Syötä suorituksia">
+                                <img src="/kipamedia/add.png"
+                                     width="32"
+                                     height="32"
+                                     alt="Syötä suorituksia" />
+                            </a>
+                            <a href="/kipa/{{ kisa_nimi }}/syota/tarkistus/"
+                               class="sitetoolbarnav"
+                               title="Syötä suorituksia (tarkistus)">
+                                <img src="/kipamedia/accept.png"
+                                     width="32"
+                                     height="32"
+                                     alt="Syötä suorituksia (tarkistus)" />
+                            </a>
+                            <a href="/kipa/{{ kisa_nimi }}/tulosta/normaali/"
+                               class="sitetoolbarnav"
+                               title="Tulokset">
+                                <img src="/kipamedia/chart.png" width="32" height="32" alt="Tulokset" />
+                            </a>
+                            <a href="/kipa/{{ kisa_nimi }}/tulosta/tilanne/"
+                               class="sitetoolbarnav"
+                               title="Laskennan tilanne">
+                                <img src="/kipamedia/chart_up.png"
+                                     width="32"
+                                     height="32"
+                                     alt="Laskennan tilanne" />
+                            </a>
+                            <a href="/kipa/{{ kisa_nimi }}/maarita/vartiot/"
+                               class="sitetoolbarnav"
+                               title="Määrittele vartiot">
+                                <img src="/kipamedia/edit_profile.png"
+                                     width="32"
+                                     height="32"
+                                     alt="Määrittele vartiot" />
+                            </a>
+                            <a href="/kipa/{{ kisa_nimi }}/maarita/tehtava/"
+                               class="sitetoolbarnav"
+                               title="Määrittele tehtävät">
+                                <img src="/kipamedia/edit_page.png"
+                                     width="32"
+                                     height="32"
+                                     alt="Määrittele tehtävät" />
+                            </a>
+                            <a href="/kipamedia/Manuaali_v03.pdf"
+                               class="sitetoolbarnav"
+                               title="Apua">
+                                <img src="/kipamedia/help.png" width="32" height="32" alt="Apua" />
+                            </a>
+                        </div>
+                    </div>
+                    <div id="right" class="column">
+                        {% block content %}{% endblock %}
+                        {% if tabs %}
+                            {% for tab in tabs %}
                                 <script type="text/javascript">
                                         var sarjat=new ddtabcontent("{{tab}}")
                                         sarjat.setpersist(true)
                                         sarjat.setselectedClassTarget("link") //"link" or "linkparent"
                                         sarjat.init()
                                 </script>
-                        {% endfor %}
-                {% else %}
-                        <script type="text/javascript">
+                            {% endfor %}
+                        {% else %}
+                            <script type="text/javascript">
                                 var sarjat=new ddtabcontent("sarjatabs")
                                 sarjat.setpersist(true)
                                 sarjat.setselectedClassTarget("link") //"link" or "linkparent"
                                 sarjat.init()
-                        </script>
-                {% endif %}
-
+                            </script>
+                        {% endif %}
+                    </div>
+                </div>
             </div>
-
         </div>
-
-    </div>
-
-</div>
-
-</body>
-
+    </body>
 </html>

--- a/web/templates/tupa/base_riisuttu.html
+++ b/web/templates/tupa/base_riisuttu.html
@@ -42,7 +42,7 @@ document.getElementById(id).style.display = visibility;
         <div style="float:right; margin-top:-4px; margin-bottom:0; padding-bottom:0; height:18px;">
             {% include "tupa/login.html" %}
         </div>
-    </div><!-- /header -->
+    </div>
     <div id="breadcrumbs"><a href="/kipa/">&lt;- Takaisin etusivulle</a> </div>
     <div id="main" class="clearfix">
 
@@ -70,10 +70,10 @@ document.getElementById(id).style.display = visibility;
                         </script>
                 {% endif %}
 
-            </div><!-- /right -->
-        </div><!-- /container -->
-    </div><!-- /main -->
-</div><!-- /wrap -->
+            </div>
+        </div>
+    </div>
+</div>
 
 </body>
 </html>

--- a/web/templates/tupa/base_riisuttu.html
+++ b/web/templates/tupa/base_riisuttu.html
@@ -1,79 +1,76 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Kipa - {% block title %}  {% endblock %}</title>
-<link rel="stylesheet" type="text/css" href="/kipamedia/kipa.css" />
-<link rel="stylesheet" type="text/css" href="/kipamedia/tabcontent.css" />
-<link rel="icon" type="image/x-icon" href="/kipamedia/favicon.ico" />
-{% block header %}  {% endblock %}
-<script type="text/javascript" language="javascript" src="/kipamedia/tooltip.js"></script>
-<script type="text/javascript" src="/kipamedia/tabcontent.js">
-/***********************************************
-* Tab Content script v2.2- © Dynamic Drive DHTML code library (www.dynamicdrive.com)
-* This notice MUST stay intact for legal use
-* Visit Dynamic Drive at http://www.dynamicdrive.com/ for full source code
-***********************************************/
-</script>
-
-<script language="JavaScript">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>Kipa -
+            {% block title %}{% endblock %}
+        </title>
+        <link rel="stylesheet" type="text/css" href="/kipamedia/kipa.css" />
+        <link rel="stylesheet" type="text/css" href="/kipamedia/tabcontent.css" />
+        <link rel="icon" type="image/x-icon" href="/kipamedia/favicon.ico" />
+        {% block header %}{% endblock %}
+        <script type="text/javascript"
+                language="javascript"
+                src="/kipamedia/tooltip.js"></script>
+        <script type="text/javascript" src="/kipamedia/tabcontent.js">
+            /***********************************************
+            * Tab Content script v2.2- © Dynamic Drive DHTML code library (www.dynamicdrive.com)
+            * This notice MUST stay intact for legal use
+            * Visit Dynamic Drive at http://www.dynamicdrive.com/ for full source code
+            ***********************************************/
+        </script>
+        <script language="JavaScript">
 function setVisibility(id, visibility) {
 document.getElementById(id).style.display = visibility;
 }
-</script>
-{% if talletettu %}
-<script type="text/javascript">
-   $.jGrowl.defaults.position = 'center';
-</script>
-    <script type="text/javascript">
+        </script>
+        {% if talletettu %}
+            <script type="text/javascript">$.jGrowl.defaults.position = 'center';</script>
+            <script type="text/javascript">
         $(document).ready(function() {
             $.jGrowl('{{talletettu}}', {
                 life: 3000
                 });
         });
-    </script>
-{% endif %}
-
-</head>
-
-<body>
-
-<div id="wrap">
-    <div id="header"><div id="pageTitle">Uusi kisa</div>
-        <div style="float:right; margin-top:-4px; margin-bottom:0; padding-bottom:0; height:18px;">
-            {% include "tupa/login.html" %}
-        </div>
-    </div>
-    <div id="breadcrumbs"><a href="/kipa/">&lt;- Takaisin etusivulle</a> </div>
-    <div id="main" class="clearfix">
-
-        <div id="container">
-            <div id="right" class="column">
-
-                {% block content %}{% endblock %}
-
-                {% if tabs %}
-                        {% for tab in tabs %}
+            </script>
+        {% endif %}
+    </head>
+    <body>
+        <div id="wrap">
+            <div id="header">
+                <div id="pageTitle">Uusi kisa</div>
+                <div style="float:right;
+                            margin-top:-4px;
+                            margin-bottom:0;
+                            padding-bottom:0;
+                            height:18px">{% include "tupa/login.html" %}</div>
+            </div>
+            <div id="breadcrumbs">
+                <a href="/kipa/">&lt;- Takaisin etusivulle</a>
+            </div>
+            <div id="main" class="clearfix">
+                <div id="container">
+                    <div id="right" class="column">
+                        {% block content %}{% endblock %}
+                        {% if tabs %}
+                            {% for tab in tabs %}
                                 <script type="text/javascript">
                                         var sarjat=new ddtabcontent("{{tab}}")
                                         sarjat.setpersist(true)
                                         sarjat.setselectedClassTarget("link") //"link" or "linkparent"
                                         sarjat.init()
                                 </script>
-
-                        {% endfor %}
-                {% else %}
-                        <script type="text/javascript">
+                            {% endfor %}
+                        {% else %}
+                            <script type="text/javascript">
                                 var sarjat=new ddtabcontent("sarjatabs")
                                 sarjat.setpersist(true)
                                 sarjat.setselectedClassTarget("link") //"link" or "linkparent"
                                 sarjat.init()
-                        </script>
-                {% endif %}
-
+                            </script>
+                        {% endif %}
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
-</div>
-
-</body>
+    </body>
 </html>

--- a/web/templates/tupa/forms/aika_vali.html
+++ b/web/templates/tupa/forms/aika_vali.html
@@ -1,25 +1,27 @@
 <fieldset>
-
-<legend> <b>Alkuaika ja loppuaika</b> </legend>
-<font color=red>
-    <b>{{kali_vihje_a.errors}}</b>
-</font>
-Syötteen 1 kuvaus (esim. Alkuaika): <input type="text"
-                        name="{{kali_vihje_a.name}}"
-                        id="{{kali_vihje_a.id}}"
-                        value="{{kali_vihje_a.value}}" />
-<br> <br>
-<font color=red>
-    <b>{{kali_vihje_b.errors}}</b>
-</font>
-Syötteen 2 kuvaus (esim. Loppuaika): <input type="text"
-                        name="{{kali_vihje_b.name}}"
-                        id="{{kali_vihje_b.id}}"
-                        value="{{kali_vihje_b.value}}" />
-<br> <br>
-
-{% include "tupa/forms/maksimi_suoritus.html" %}
-{% include "tupa/forms/nolla_suoritus.html" %}
-
+    <legend>
+        <b>Alkuaika ja loppuaika</b>
+    </legend>
+    <font color=red>
+        <b>{{ kali_vihje_a.errors }}</b>
+    </font>
+    Syötteen 1 kuvaus (esim. Alkuaika):
+    <input type="text"
+           name="{{ kali_vihje_a.name }}"
+           id="{{ kali_vihje_a.id }}"
+           value="{{ kali_vihje_a.value }}" />
+    <br>
+    <br>
+    <font color=red>
+        <b>{{ kali_vihje_b.errors }}</b>
+    </font>
+    Syötteen 2 kuvaus (esim. Loppuaika):
+    <input type="text"
+           name="{{ kali_vihje_b.name }}"
+           id="{{ kali_vihje_b.id }}"
+           value="{{ kali_vihje_b.value }}" />
+    <br>
+    <br>
+    {% include "tupa/forms/maksimi_suoritus.html" %}
+    {% include "tupa/forms/nolla_suoritus.html" %}
 </fieldset>
-

--- a/web/templates/tupa/forms/aika_vali.html
+++ b/web/templates/tupa/forms/aika_vali.html
@@ -1,17 +1,17 @@
 <fieldset>
 
 <legend> <b>Alkuaika ja loppuaika</b> </legend>
-<font color=red><b>
-{{kali_vihje_a.errors}}
-</b></font>
+<font color=red>
+    <b>{{kali_vihje_a.errors}}</b>
+</font>
 Syötteen 1 kuvaus (esim. Alkuaika): <input type="text"
                         name="{{kali_vihje_a.name}}"
                         id="{{kali_vihje_a.id}}"
                         value="{{kali_vihje_a.value}}" />
 <br> <br>
-<font color=red><b>
-{{kali_vihje_b.errors}}
-</b></font>
+<font color=red>
+    <b>{{kali_vihje_b.errors}}</b>
+</font>
 Syötteen 2 kuvaus (esim. Loppuaika): <input type="text"
                         name="{{kali_vihje_b.name}}"
                         id="{{kali_vihje_b.id}}"

--- a/web/templates/tupa/forms/arviointi.html
+++ b/web/templates/tupa/forms/arviointi.html
@@ -8,9 +8,9 @@
 <td width=300>
 <p>Käytössa: <input type="checkbox" name="{{arvio.name}}" id="{{arvio.id}}" value="abs"
 {% if arvio.value == "abs" %}checked="checked" {% endif %}/></p>
-<p><font color=red><b>
-                        {{oikea.errors}}
-</b></font>
+<p><font color=red>
+    <b>{{oikea.errors}}</b>
+</font>
 Oikea vastaus: <input type="text" name="{{oikea.name}}" id="{{oikea.id}}" value="{{oikea.value}}" /> <br>
 </td>
 <td>

--- a/web/templates/tupa/forms/arviointi.html
+++ b/web/templates/tupa/forms/arviointi.html
@@ -1,26 +1,35 @@
-
 <fieldset>
-<legend> <b>Arviointi</b> </legend>
-
-<table>
-
-<tr>
-<td width=300>
-<p>Käytössa: <input type="checkbox" name="{{arvio.name}}" id="{{arvio.id}}" value="abs"
-{% if arvio.value == "abs" %}checked="checked" {% endif %}/></p>
-<p><font color=red>
-    <b>{{oikea.errors}}</b>
-</font>
-Oikea vastaus: <input type="text" name="{{oikea.name}}" id="{{oikea.id}}" value="{{oikea.value}}" /> <br>
-</td>
-<td>
-
-Jos kyseessä on tavallinen tehtävä, tätä ei valita.
-Mikäli kyseessä on arviointitehtävä, tulee tässä ilmoittaa tehtävän oikea vastaus.
-Tällöin vartioiden suoritukset täman arvon molemmin puolin ovat samanarvoisia.</p>
-</td>
-</tr>
-</table>
+    <legend>
+        <b>Arviointi</b>
+    </legend>
+    <table>
+        <tr>
+            <td width=300>
+                <p>
+                    Käytössa:
+                    <input type="checkbox"
+                           name="{{ arvio.name }}"
+                           id="{{ arvio.id }}"
+                           value="abs"
+                           {% if arvio.value == "abs" %}checked="checked"{% endif %} />
+                </p>
+                <p>
+                    <font color=red>
+                        <b>{{ oikea.errors }}</b>
+                    </font>
+                    Oikea vastaus:
+                    <input type="text"
+                           name="{{ oikea.name }}"
+                           id="{{ oikea.id }}"
+                           value="{{ oikea.value }}" />
+                    <br>
+                </td>
+                <td>
+                    Jos kyseessä on tavallinen tehtävä, tätä ei valita.
+                    Mikäli kyseessä on arviointitehtävä, tulee tässä ilmoittaa tehtävän oikea vastaus.
+                    Tällöin vartioiden suoritukset täman arvon molemmin puolin ovat samanarvoisia.
+                </p>
+            </td>
+        </tr>
+    </table>
 </fieldset>
-
-

--- a/web/templates/tupa/forms/funktiot_apu.html
+++ b/web/templates/tupa/forms/funktiot_apu.html
@@ -1,5 +1,4 @@
 <span onmouseover="tooltip.show('<b>Perusfunktiot:</b><br>aikavali(a,b) - vuorokauden ylittävä kello<br>abs(x) - itseisarvo<br>log(x) - logaritmi10<br>ln(x) - luonnollinen logaritmi<br>floor(x) - pyöristys alas<br>ceil(x) - pyöristys ylös<br>sqrt(x) - neliöjuuri<br>exp(x) - exponentti<br>mod(x,y) - jakojäännös<br>pow(x,y) - potenssi<br> interpoloi(x,x1,y1,x2,(y2=0))<br><br><b>Listafunktiot:</b><br>min(x,(...) ), pienin(x, (...) )<br>max(x, (...) ), suurin(x, (...) )<br>sum(x, (...) ) - summa<br>med(x, (...) ) - mediaani<br>kesk(x, (...) ) - keskiarvo' );"
-onmouseout="tooltip.hide();">
+      onmouseout="tooltip.hide();">
     <img src="/kipamedia/help_small.png" />
 </span>
-

--- a/web/templates/tupa/forms/kisa_piste.html
+++ b/web/templates/tupa/forms/kisa_piste.html
@@ -1,6 +1,6 @@
-<font color=red><b>
-{{kali_vihje_a.errors}}
-</b></font>
+<font color=red>
+    <b>{{kali_vihje_a.errors}}</b>
+</font>
 Syötteen kuvaus : <input type="text" name="{{kali_vihje_a.name}}" id="{{kali_vihje_a.id}}" value="{{kali_vihje_a.value}}" /><br> <br>
 
 

--- a/web/templates/tupa/forms/kisa_piste.html
+++ b/web/templates/tupa/forms/kisa_piste.html
@@ -1,6 +1,10 @@
 <font color=red>
-    <b>{{kali_vihje_a.errors}}</b>
+    <b>{{ kali_vihje_a.errors }}</b>
 </font>
-Syötteen kuvaus : <input type="text" name="{{kali_vihje_a.name}}" id="{{kali_vihje_a.id}}" value="{{kali_vihje_a.value}}" /><br> <br>
-
-
+Syötteen kuvaus :
+<input type="text"
+       name="{{ kali_vihje_a.name }}"
+       id="{{ kali_vihje_a.id }}"
+       value="{{ kali_vihje_a.value }}" />
+<br>
+<br>

--- a/web/templates/tupa/forms/kokonais_aika.html
+++ b/web/templates/tupa/forms/kokonais_aika.html
@@ -1,15 +1,13 @@
-
 <font color=red>
-    <b>{{kali_vihje_a.errors}}</b>
+    <b>{{ kali_vihje_a.errors }}</b>
 </font>
-Syötteen kuvaus : <input type="text"
-                        name="{{kali_vihje_a.name}}"
-                        id="{{kali_vihje_a.id}}"
-                        value="{{kali_vihje_a.value}}" />
-<br> <br>
-
+Syötteen kuvaus :
+<input type="text"
+       name="{{ kali_vihje_a.name }}"
+       id="{{ kali_vihje_a.id }}"
+       value="{{ kali_vihje_a.value }}" />
+<br>
+<br>
 {% include "tupa/forms/maksimi_suoritus.html" %}
 {% include "tupa/forms/nolla_suoritus.html" %}
 {% include "tupa/forms/arviointi.html" %}
-
-

--- a/web/templates/tupa/forms/kokonais_aika.html
+++ b/web/templates/tupa/forms/kokonais_aika.html
@@ -1,7 +1,7 @@
 
-<font color=red><b>
-{{kali_vihje_a.errors}}
-</b></font>
+<font color=red>
+    <b>{{kali_vihje_a.errors}}</b>
+</font>
 Syötteen kuvaus : <input type="text"
                         name="{{kali_vihje_a.name}}"
                         id="{{kali_vihje_a.id}}"

--- a/web/templates/tupa/forms/maksimi_suoritus.html
+++ b/web/templates/tupa/forms/maksimi_suoritus.html
@@ -5,8 +5,9 @@
 <table>
 <tr>
 <td width=400>
-<font color=red><b>
-</b></font>
+<font color=red>
+    <b></b>
+</font>
 Parhaat pisteet saa:<br>
 <input type="radio" id="{{parhaan_haku.id}}_1" value="min" name="{{parhaan_haku.name}}"
 {% if parhaan_haku.value == "min" %}checked="checked" {% endif %}
@@ -24,16 +25,16 @@ onmouseout="tooltip.hide();">
 <img src="/kipamedia/help_small.png" />
 </span>
 {%else%} kiinteä: {% endif %}</label>
-<font color=red><b>
-        {{kiintea.errors}}
-</b></font>
+<font color=red>
+    <b>{{kiintea.errors}}</b>
+</font>
 <input type="text" size="40" name="{{kiintea.name}}" id="{{kiintea.id}}" value="{{kiintea.value}}"{%if vapaa %}size=80{% endif %} /><br>
 
 <font color=red><b>  </b></font>
 Montako kisapistettä jaetaan:
-<font color=red><b>
-        {{jaettavat.errors}}
-</b></font>
+<font color=red>
+<b>{{jaettavat.errors}}</b>
+</font>
 <input type="text" size="6" name="{{jaettavat.name}}" id="{{jaettavat.id}}" value="{{jaettavat.value}}" />
 </td>
 <td>

--- a/web/templates/tupa/forms/maksimi_suoritus.html
+++ b/web/templates/tupa/forms/maksimi_suoritus.html
@@ -1,47 +1,69 @@
 <fieldset>
-
-<legend> <b>Maksimisuoritus</b> </legend>
-
-<table>
-<tr>
-<td width=400>
-<font color=red>
-    <b></b>
-</font>
-Parhaat pisteet saa:<br>
-<input type="radio" id="{{parhaan_haku.id}}_1" value="min" name="{{parhaan_haku.name}}"
-{% if parhaan_haku.value == "min" %}checked="checked" {% endif %}
-/> <label for="{{parhaan_haku.id}}_1">pienin</label><br>
-<input type="radio" id="{{parhaan_haku.id}}_2" value="max" name="{{parhaan_haku.name}}"
-{% if parhaan_haku.value == "max" %}checked="checked" {% endif %}
-/> <label for="{{parhaan_haku.id}}_2">suurin</label><br>
-<input type="radio" id="{{parhaan_haku.id}}_3" value="" name="{{parhaan_haku.name}}"
-{% if parhaan_haku.value == "" %}checked="checked" {% endif %}
-/>
-<label for="{{parhaan_haku.id}}_3">
-{%if vapaa %} kaava:
-<span onmouseover="tooltip.show('Tähän tulee kaava, joka määrittää suorituksen, jolla saa täydet pisteet.<br> Kaavassa voi käyttää normaalien funktioiden lisäksi muutamaa lisäviitettä:<br>suor (kaikkien vartioiden suoritukset)<br>muk (mukana olevien vartioiden suodatin)<br><br>Esimerkiksi<br>min(suor*muk) pienin mukana olevan vartion suoritus<br>' );"
-onmouseout="tooltip.hide();">
-<img src="/kipamedia/help_small.png" />
-</span>
-{%else%} kiinteä: {% endif %}</label>
-<font color=red>
-    <b>{{kiintea.errors}}</b>
-</font>
-<input type="text" size="40" name="{{kiintea.name}}" id="{{kiintea.id}}" value="{{kiintea.value}}"{%if vapaa %}size=80{% endif %} /><br>
-
-<font color=red><b>  </b></font>
-Montako kisapistettä jaetaan:
-<font color=red>
-<b>{{jaettavat.errors}}</b>
-</font>
-<input type="text" size="6" name="{{jaettavat.name}}" id="{{jaettavat.id}}" value="{{jaettavat.value}}" />
-</td>
-<td>
-Tässä kerrotaan suoritus, jolla saa maksimipisteet. Tämä voi olla vartioiden suorituksista pienin, suurin tai jokin kiinteä luku. Mikäli kyseessä on arviointi valitse pienin.
-</td>
-</tr>
-</table>
-
+    <legend>
+        <b>Maksimisuoritus</b>
+    </legend>
+    <table>
+        <tr>
+            <td width=400>
+                <font color=red>
+                    <b></b>
+                </font>
+                Parhaat pisteet saa:
+                <br>
+                <input type="radio"
+                       id="{{ parhaan_haku.id }}_1"
+                       value="min"
+                       name="{{ parhaan_haku.name }}"
+                       {% if parhaan_haku.value == "min" %}checked="checked"{% endif %} />
+                <label for="{{ parhaan_haku.id }}_1">pienin</label>
+                <br>
+                <input type="radio"
+                       id="{{ parhaan_haku.id }}_2"
+                       value="max"
+                       name="{{ parhaan_haku.name }}"
+                       {% if parhaan_haku.value == "max" %}checked="checked"{% endif %} />
+                <label for="{{ parhaan_haku.id }}_2">suurin</label>
+                <br>
+                <input type="radio"
+                       id="{{ parhaan_haku.id }}_3"
+                       value=""
+                       name="{{ parhaan_haku.name }}"
+                       {% if parhaan_haku.value == "" %}checked="checked"{% endif %} />
+                <label for="{{ parhaan_haku.id }}_3">
+                    {% if vapaa %}
+                        kaava:
+                        <span onmouseover="tooltip.show('Tähän tulee kaava, joka määrittää suorituksen, jolla saa täydet pisteet.<br> Kaavassa voi käyttää normaalien funktioiden lisäksi muutamaa lisäviitettä:<br>suor (kaikkien vartioiden suoritukset)<br>muk (mukana olevien vartioiden suodatin)<br><br>Esimerkiksi<br>min(suor*muk) pienin mukana olevan vartion suoritus<br>' );"
+                              onmouseout="tooltip.hide();">
+                            <img src="/kipamedia/help_small.png" />
+                        </span>
+                    {% else %}
+                        kiinteä:
+                    {% endif %}
+                </label>
+                <font color=red>
+                    <b>{{ kiintea.errors }}</b>
+                </font>
+                <input type="text"
+                       size="40"
+                       name="{{ kiintea.name }}"
+                       id="{{ kiintea.id }}"
+                       value="{{ kiintea.value }}"
+                       {% if vapaa %}size=80{% endif %} />
+                <br>
+                <font color=red><b>  </b></font>
+                Montako kisapistettä jaetaan:
+                <font color=red>
+                    <b>{{ jaettavat.errors }}</b>
+                </font>
+                <input type="text"
+                       size="6"
+                       name="{{ jaettavat.name }}"
+                       id="{{ jaettavat.id }}"
+                       value="{{ jaettavat.value }}" />
+            </td>
+            <td>
+                Tässä kerrotaan suoritus, jolla saa maksimipisteet. Tämä voi olla vartioiden suorituksista pienin, suurin tai jokin kiinteä luku. Mikäli kyseessä on arviointi valitse pienin.
+            </td>
+        </tr>
+    </table>
 </fieldset>
-

--- a/web/templates/tupa/forms/nolla_suoritus.html
+++ b/web/templates/tupa/forms/nolla_suoritus.html
@@ -1,81 +1,96 @@
 <fieldset>
-<legend> <b>Nollasuoritus</b> </legend>
-        <table border="0">
-<p>
-        Tässä kerrotaan suoritus, jolla saa nolla pistettä.
-        Tämä voi olla jokin kiinteä suoritus tai interpoloinnissa keskimmäisestä tuloksesta laskettu.
-</p>
-
-<tr valign="top">
-<td>
-        <font color=red>
-            <b></b>
-        </font>
-</td>
-<td>
-</td>
-<td>
-        <fieldset>
-                <legend>{%if vapaa %} Vapaa: {%else%} Kiinteä {% endif %}</legend>
-                <p>
-        <input type="radio" id="{{nollan_kerroin.id}}" value="1" name="{{nollan_kerroin.name}}"
-        {% if nollan_kerroin.value == "1" %}
-        checked="checked"
-        {% endif %}
-        {% if not nollan_kerroin.value %}
-        checked="checked"
-        {% endif %} />
-                        {%if vapaa %} kaava:
-                        <span onmouseover="tooltip.show('Tähän tulee kaava, joka määrittää suorituksen, jolla saa nolla pistettä.<br> Kaavassa voi käyttää normaalien funktioiden lisäksi muutamaa lisäviitettä:<br>suor (kaikkien vartioiden suoritukset)<br>muk (mukana olevien vartioiden suodatin)<br><br>Esimerkiksi<br>min(suor*muk) pienin mukana olevan vartion suoritus<br>' );"
-onmouseout="tooltip.hide();">
-<img src="/kipamedia/help_small.png" />
-</span>
-                        {%else%}  Kiinteä suoritus: {% endif %}
+    <legend>
+        <b>Nollasuoritus</b>
+    </legend>
+    <table border="0">
+        <p>
+            Tässä kerrotaan suoritus, jolla saa nolla pistettä.
+            Tämä voi olla jokin kiinteä suoritus tai interpoloinnissa keskimmäisestä tuloksesta laskettu.
+        </p>
+        <tr valign="top">
+            <td>
+                <font color=red>
+                    <b></b>
+                </font>
+            </td>
+            <td></td>
+            <td>
+                <fieldset>
+                    <legend>
+                        {% if vapaa %}
+                            Vapaa:
+                        {% else %}
+                            Kiinteä
+                        {% endif %}
+                    </legend>
+                    <p>
+                        <input type="radio"
+                               id="{{ nollan_kerroin.id }}"
+                               value="1"
+                               name="{{ nollan_kerroin.name }}"
+                               {% if nollan_kerroin.value == "1" %}checked="checked"{% endif %}
+                               {% if not nollan_kerroin.value %}checked="checked"{% endif %} />
+                        {% if vapaa %}
+                            kaava:
+                            <span onmouseover="tooltip.show('Tähän tulee kaava, joka määrittää suorituksen, jolla saa nolla pistettä.<br> Kaavassa voi käyttää normaalien funktioiden lisäksi muutamaa lisäviitettä:<br>suor (kaikkien vartioiden suoritukset)<br>muk (mukana olevien vartioiden suodatin)<br><br>Esimerkiksi<br>min(suor*muk) pienin mukana olevan vartion suoritus<br>' );"
+                                  onmouseout="tooltip.hide();">
+                                <img src="/kipamedia/help_small.png" />
+                            </span>
+                        {% else %}
+                            Kiinteä suoritus:
+                        {% endif %}
                         <font color=red>
-                        <b>{{nollan_kaava.errors}}</b>
+                            <b>{{ nollan_kaava.errors }}</b>
                         </font>
-                        <input type="text" name="{{nollan_kaava.name}}" id="{{nollan_kaava.id}}" value="{{nollan_kaava.value}}" {% if vapaa %} size=40 {%endif %} ><br>
-                </p>
+                        <input type="text"
+                               name="{{ nollan_kaava.name }}"
+                               id="{{ nollan_kaava.id }}"
+                               value="{{ nollan_kaava.value }}"
+                               {% if vapaa %}size=40{% endif %}>
+                        <br>
+                    </p>
                 </fieldset>
-</td>
-
-<td>
-        <fieldset>
-                <legend>Kerroin keskimmäisestä tuloksesta</legend>
-
-                   <p>
+            </td>
+            <td>
+                <fieldset>
+                    <legend>Kerroin keskimmäisestä tuloksesta</legend>
+                    <p>
                         <font color=red>
                             <b></b>
                         </font>
-
-<input type="radio" id="{{nollan_kerroin.id}}" value="1.5" name="{{nollan_kerroin.name}}"
-{% if nollan_kerroin.value == "1.5" %}checked="checked" {% endif %}/>
-1.5 (pienin tulos saa parhaat pisteet)<br>
-<input type="radio" id="{{nollan_kerroin.id}}" value="0.5" name="{{nollan_kerroin.name}}"
-{% if nollan_kerroin.value == "0.5" %}checked="checked" {% endif%}/>
-0.5 (suurin tulos saa parhaat pisteet)<br>
-<input type="radio" id="{{nollan_kerroin.id}}" value="m" name="{{nollan_kerroin.name}}"
-{% if nollan_kerroin.value != "1.5" %}
-{% if nollan_kerroin.value != "0.5" %}
-{% if nollan_kerroin.value != "1" %}
-{% if nollan_kerroin.value %}
-
-checked="checked"
-{% endif %}
-{% endif %}
-{% endif %}
-{% endif %}/>
-
-muu:
-
+                        <input type="radio"
+                               id="{{ nollan_kerroin.id }}"
+                               value="1.5"
+                               name="{{ nollan_kerroin.name }}"
+                               {% if nollan_kerroin.value == "1.5" %}checked="checked"{% endif %} />
+                        1.5 (pienin tulos saa parhaat pisteet)
+                        <br>
+                        <input type="radio"
+                               id="{{ nollan_kerroin.id }}"
+                               value="0.5"
+                               name="{{ nollan_kerroin.name }}"
+                               {% if nollan_kerroin.value == "0.5" %}checked="checked"{% endif %} />
+                        0.5 (suurin tulos saa parhaat pisteet)
+                        <br>
+                        <input type="radio"
+                               id="{{ nollan_kerroin.id }}"
+                               value="m"
+                               name="{{ nollan_kerroin.name }}"
+                               {% if nollan_kerroin.value != "1.5" %} {% if nollan_kerroin.value != "0.5" %} {% if nollan_kerroin.value != "1" %} {% if nollan_kerroin.value %}checked="checked"{% endif %}
+                               {% endif %}
+                               {% endif %}
+                               {% endif %} />
+                        muu:
                         <font color=red>
-                        <b>{{muu_kerroin.errors}}</b>
+                            <b>{{ muu_kerroin.errors }}</b>
                         </font>
-                      <input type="text" name="{{muu_kerroin.name}}" id="{{muu_kerroin.id}}" value="{{muu_kerroin.value}}" />
+                        <input type="text"
+                               name="{{ muu_kerroin.name }}"
+                               id="{{ muu_kerroin.id }}"
+                               value="{{ muu_kerroin.value }}" />
                     </p>
                 </fieldset>
-</td>
-</tr>
-</table>
+            </td>
+        </tr>
+    </table>
 </fieldset>
-

--- a/web/templates/tupa/forms/nolla_suoritus.html
+++ b/web/templates/tupa/forms/nolla_suoritus.html
@@ -8,8 +8,9 @@
 
 <tr valign="top">
 <td>
-        <font color=red><b>
-        </b></font>
+        <font color=red>
+            <b></b>
+        </font>
 </td>
 <td>
 </td>
@@ -30,9 +31,9 @@ onmouseout="tooltip.hide();">
 <img src="/kipamedia/help_small.png" />
 </span>
                         {%else%}  Kiinteä suoritus: {% endif %}
-                        <font color=red><b>
-                        {{nollan_kaava.errors}}
-                        </b></font>
+                        <font color=red>
+                        <b>{{nollan_kaava.errors}}</b>
+                        </font>
                         <input type="text" name="{{nollan_kaava.name}}" id="{{nollan_kaava.id}}" value="{{nollan_kaava.value}}" {% if vapaa %} size=40 {%endif %} ><br>
                 </p>
                 </fieldset>
@@ -43,8 +44,9 @@ onmouseout="tooltip.hide();">
                 <legend>Kerroin keskimmäisestä tuloksesta</legend>
 
                    <p>
-                        <font color=red><b>
-                        </b></font>
+                        <font color=red>
+                            <b></b>
+                        </font>
 
 <input type="radio" id="{{nollan_kerroin.id}}" value="1.5" name="{{nollan_kerroin.name}}"
 {% if nollan_kerroin.value == "1.5" %}checked="checked" {% endif %}/>
@@ -66,9 +68,9 @@ checked="checked"
 
 muu:
 
-                        <font color=red><b>
-                        {{muu_kerroin.errors}}
-                        </b></font>
+                        <font color=red>
+                        <b>{{muu_kerroin.errors}}</b>
+                        </font>
                       <input type="text" name="{{muu_kerroin.name}}" id="{{muu_kerroin.id}}" value="{{muu_kerroin.value}}" />
                     </p>
                 </fieldset>

--- a/web/templates/tupa/forms/operaattorit_apu.html
+++ b/web/templates/tupa/forms/operaattorit_apu.html
@@ -1,5 +1,4 @@
 <span onmouseover="tooltip.show('<b>Aritmeettiset operaattorit:</b><br>+ yhteenlasku<br>- vähennys<br>* kertolasku<br>/ jakolasku<br><br><b>Vertailuoperaattorit (tuottavat 1 tai 0):</b><br>< pienempi<br>> suurempi<br>== yhtäsuuri<br>!= erisuuri <br>&lt= pienempi tai yhtäsuuri<br> &gt= suurempi tai yhtäsuuri<br>' );"
-onmouseout="tooltip.hide();">
+      onmouseout="tooltip.hide();">
     <img src="/kipamedia/help_small.png" />
 </span>
-

--- a/web/templates/tupa/forms/osa_tehtava.html
+++ b/web/templates/tupa/forms/osa_tehtava.html
@@ -1,52 +1,37 @@
 <h1>{{ heading }}</h1>
-
 <fieldset>
-<legend><b>Osatehtävä {{ nimi }}</b></legend>
-
-<style type="text/css">
-
+    <legend>
+        <b>Osatehtävä {{ nimi }}</b>
+    </legend>
+    <style type="text/css">
 .hidden
 {
     display: none;
 }
 
-</style>
-<font color=red><b> {{osatehtava.errors}} </b> </font>
-{% if taulukko %}
-
-Osatehtävän tyyppi:
-<span onmouseover="tooltip.show('<b>Kisapiste</b> on yksi syöte, joka ei vaadi laskentaa. <br /><b>Raakapiste</b> on syöte, jonka perusteella lasketaan vartiolle kisapisteet, esim. interpoloimalla. <br /><b>Kokonaisaika</b> on aikasyöte, jonka perusteella lasketaan vartiolle kisapisteet. <br /><b>Aikaväliin</b> syötetään alkuaika ja loppuaika, jonka perusteella Kipa laskee vartion suoritusajan ja senmukaiset kisapisteet. <br /><b>Vapaakaava</b> antaa mahdollisuuden määritellä matemaattisen kaavan, jonka perusteella lasketaan syötteistä kisapisteet. <br /><b>Puhdaskaavalla</b> voi määritellä täysin vapaasti Kipan syötteiden laskennan.');" onmouseout="tooltip.hide();">
-    <img src="/kipamedia/help_small.png" />
-</span>
-
-{% for sarake in taulukko%}
-        <input type="radio" name="{{osatehtava.id}}" value="{{sarake.tyyppi}}"
-        onclick="
-        {% for sa in taulukko%}
-                {%if sa.tyyppi == sarake.tyyppi %}
-                        setVisibility('{{sa.id}}','inline');
-                {% else %}
-                        setVisibility('{{sa.id}}','none');
-                {% endif %}
-        {% endfor %} "
-
-        {%if sarake.tyyppi == tyyppi %} checked='checked' {% endif %} />
-        {{sarake.otsikko}} &nbsp; &nbsp;
-{% endfor %}
-{% for sarake in taulukko%}
-
-        <div id="{{sarake.id}}" class='hidden' >
-
-        <table border="0">
-            <td>{{sarake.form}}</td>
-        </table>
-        </div>
-{% endfor %}
-<script type="text/javascript">
-setVisibility('{{nimi}}_{{tyyppi}}','inline')
-</script>
-
-{%endif%}
-
-
+    </style>
+    <font color=red><b> {{ osatehtava.errors }} </b> </font>
+    {% if taulukko %}
+        Osatehtävän tyyppi:
+        <span onmouseover="tooltip.show('<b>Kisapiste</b> on yksi syöte, joka ei vaadi laskentaa. <br /><b>Raakapiste</b> on syöte, jonka perusteella lasketaan vartiolle kisapisteet, esim. interpoloimalla. <br /><b>Kokonaisaika</b> on aikasyöte, jonka perusteella lasketaan vartiolle kisapisteet. <br /><b>Aikaväliin</b> syötetään alkuaika ja loppuaika, jonka perusteella Kipa laskee vartion suoritusajan ja senmukaiset kisapisteet. <br /><b>Vapaakaava</b> antaa mahdollisuuden määritellä matemaattisen kaavan, jonka perusteella lasketaan syötteistä kisapisteet. <br /><b>Puhdaskaavalla</b> voi määritellä täysin vapaasti Kipan syötteiden laskennan.');"
+              onmouseout="tooltip.hide();">
+            <img src="/kipamedia/help_small.png" />
+        </span>
+        {% for sarake in taulukko %}
+            <input type="radio"
+                   name="{{ osatehtava.id }}"
+                   value="{{ sarake.tyyppi }}"
+                   onclick=" {% for sa in taulukko %} {% if sa.tyyppi == sarake.tyyppi %} setVisibility('{{ sa.id }}','inline'); {% else %} setVisibility('{{ sa.id }}','none'); {% endif %} {% endfor %} "
+                   {% if sarake.tyyppi == tyyppi %}checked='checked'{% endif %} />
+            {{ sarake.otsikko }} &nbsp; &nbsp;
+        {% endfor %}
+        {% for sarake in taulukko %}
+            <div id="{{ sarake.id }}" class='hidden'>
+                <table border="0">
+                    <td>{{ sarake.form }}</td>
+                </table>
+            </div>
+        {% endfor %}
+        <script type="text/javascript">setVisibility('{{nimi}}_{{tyyppi}}','inline')</script>
+    {% endif %}
 </fieldset>

--- a/web/templates/tupa/forms/osa_tehtava.html
+++ b/web/templates/tupa/forms/osa_tehtava.html
@@ -24,9 +24,9 @@ Osatehtävän tyyppi:
         onclick="
         {% for sa in taulukko%}
                 {%if sa.tyyppi == sarake.tyyppi %}
-                        setVisibility('{{sa.id}}','inline')
+                        setVisibility('{{sa.id}}','inline');
                 {% else %}
-                        setVisibility('{{sa.id}}','none')
+                        setVisibility('{{sa.id}}','none');
                 {% endif %}
         {% endfor %} "
 

--- a/web/templates/tupa/forms/puhdas_kaava.html
+++ b/web/templates/tupa/forms/puhdas_kaava.html
@@ -1,47 +1,52 @@
-
 <b>Syötteet:</b>
-<span onmouseover="tooltip.show('Kuvaus näytetään otsikkona tehtävää syötettäessä. Tyyppi kertoo syötteen tyypin: piste vai aika.');" onmouseout="tooltip.hide();">
+<span onmouseover="tooltip.show('Kuvaus näytetään otsikkona tehtävää syötettäessä. Tyyppi kertoo syötteen tyypin: piste vai aika.');"
+      onmouseout="tooltip.hide();">
     <img src="/kipamedia/help_small.png" />
 </span>
 <br>
 <table>
-{% for maarite in maaritteet %}
-    <tr>
-        <td>Syötteen {{maarite.nimi}} kuvaus:</td>
-        <td>
-            <input type="text"
-                    name="{{maarite.kali_vihje.name}}"
-                    id="{{maarite.kali_vihje.id}}"
-                    value="{{maarite.kali_vihje.value}}" />
-                    Tyyppi:
-
-            <select name="{{maarite.tyyppi.name}}">
-                <option value="piste"
-                {% if maarite.tyyppi.value == "piste" %}selected="selected"{% endif %}
-                 >piste</option>
-                <option value="aika"
-                {% if maarite.tyyppi.value == "aika" %}selected="selected"{% endif %}
-                >aika</option>
-            </select>
-        </td>
-    </tr>
-{% endfor %}
+    {% for maarite in maaritteet %}
+        <tr>
+            <td>Syötteen {{ maarite.nimi }} kuvaus:</td>
+            <td>
+                <input type="text"
+                       name="{{ maarite.kali_vihje.name }}"
+                       id="{{ maarite.kali_vihje.id }}"
+                       value="{{ maarite.kali_vihje.value }}" />
+                Tyyppi:
+                <select name="{{ maarite.tyyppi.name }}">
+                    <option value="piste"
+                            {% if maarite.tyyppi.value == "piste" %}selected="selected"{% endif %}>piste</option>
+                    <option value="aika"
+                            {% if maarite.tyyppi.value == "aika" %}selected="selected"{% endif %}>aika</option>
+                </select>
+            </td>
+        </tr>
+    {% endfor %}
 </table>
-
-<button name="lisaa_maaritteita" type="submit" class="small blue awesome" value='{{maaritteita.name}}' title="Lisää 5 tyhjää kenttää">Lisää 5 kenttää</button><br><br>
-<font color=red><b>{{kaava.errors}}</b></font><strong>Kaavassa käytettävät funktiot:</strong>
+<button name="lisaa_maaritteita"
+        type="submit"
+        class="small blue awesome"
+        value='{{ maaritteita.name }}'
+        title="Lisää 5 tyhjää kenttää">Lisää 5 kenttää</button>
+<br>
+<br>
+<font color=red><b>{{ kaava.errors }}</b></font><strong>Kaavassa käytettävät funktiot:</strong>
 {% include "tupa/forms/funktiot_apu.html" %}
-<b>operaattorit:</b>{% include "tupa/forms/operaattorit_apu.html" %}
+<b>operaattorit:</b>
+{% include "tupa/forms/operaattorit_apu.html" %}
 <br>
 Vartion suorituksen kaava:
 <span onmouseover="tooltip.show('Anna kaava, joka määrää suoraan vartion osatehtävän pisteet. Syötteisiin ja osatehtäviin viitataan niiden kirjaimilla. Välilyöntejä sekä rivinvaihtoa voi käyttää vapaasti kaavan jäsentelyyn. Aikaa käsitellään laskennallisesti sekunteina. <br><br>Esimerkkejä:<br> a+b+c syötteiden summa <br>1/a (käänteisluku)<br>a (vartion syöte) <br>.a (sarjan kaikkien vartioiden syötteet)<br>.a.vartio (vartion syöte)  <br>min(.a) (sarjan vartioiden syötteen minimi)<br>muk ja ..mukana (mukana olevien vartioiden filtteri)<br>max(.a*muk) (mukana olevien vartioiden syöteen maksimi)<br>vartio (vartion numero)<br>..b.a.vartio (syöte a vartiolle osatehtävästä b)<br>...start.c.a.vartio (syöte a vartiolle osatehtästä c tehtävään start)' );"
-onmouseout="tooltip.hide();">
+      onmouseout="tooltip.hide();">
     <img src="/kipamedia/help_small.png" />
-</span><br />
+</span>
+<br />
 <blockquote>
-    <textarea name="{{kaava.name}}" id="{{kaava.id}}" cols="80" rows="7">{{kaava.value}}</textarea><br><br>
+    <textarea name="{{kaava.name}}" id="{{kaava.id}}" cols="80" rows="7">{{kaava.value}}</textarea>
+    <br>
+    <br>
 </blockquote>
-
-<INPUT TYPE=HIDDEN NAME="{{maaritteita.name}}" value="{{maaritteita.value}}">
-
-
+<input TYPE="HIDDEN"
+       NAME="{{ maaritteita.name }}"
+       value="{{ maaritteita.value }}">

--- a/web/templates/tupa/forms/raaka_piste.html
+++ b/web/templates/tupa/forms/raaka_piste.html
@@ -1,12 +1,16 @@
-
-        <font color=red>
-            <b><br>{{kali_vihje_a.errors}}</b>
-        </font>
-
-        Syötteen kuvaus: <input type="text" size="30" name="{{kali_vihje_a.name}}" id="{{kali_vihje_a.id}}" value="{{kali_vihje_a.value}}" /><br> <br>
-
+<font color=red>
+    <b>
+        <br>
+    {{ kali_vihje_a.errors }}</b>
+</font>
+Syötteen kuvaus:
+<input type="text"
+       size="30"
+       name="{{ kali_vihje_a.name }}"
+       id="{{ kali_vihje_a.id }}"
+       value="{{ kali_vihje_a.value }}" />
+<br>
+<br>
 {% include "tupa/forms/maksimi_suoritus.html" %}
 {% include "tupa/forms/nolla_suoritus.html" %}
 {% include "tupa/forms/arviointi.html" %}
-
-

--- a/web/templates/tupa/forms/raaka_piste.html
+++ b/web/templates/tupa/forms/raaka_piste.html
@@ -1,7 +1,7 @@
 
-        <font color=red><b> <br>
-        {{kali_vihje_a.errors}}
-        </b></font>
+        <font color=red>
+            <b><br>{{kali_vihje_a.errors}}</b>
+        </font>
 
         Syötteen kuvaus: <input type="text" size="30" name="{{kali_vihje_a.name}}" id="{{kali_vihje_a.id}}" value="{{kali_vihje_a.value}}" /><br> <br>
 

--- a/web/templates/tupa/forms/syote_maarite.html
+++ b/web/templates/tupa/forms/syote_maarite.html
@@ -1,8 +1,5 @@
-
 {% for field in form %}
-
-       <font color=red><b> {{field.errors}} </b></font>
-        {{field.label}} : {{field}} <br>
-
+    <font color=red><b> {{ field.errors }} </b></font>
+    {{ field.label }} : {{ field }}
+    <br>
 {% endfor %}
-

--- a/web/templates/tupa/forms/tehtava.html
+++ b/web/templates/tupa/forms/tehtava.html
@@ -1,65 +1,97 @@
-
 <font color=red>
-<b>{{nimi.errors}}</b>
+    <b>{{ nimi.errors }}</b>
 </font>
 Nimi:*
-<span onmouseover="tooltip.show('Anna tehtävän nimi. Älä käytä ääkkösiä, välilyöntiä tai muita erikoismerkkejä. Korvaa välilyönnit alaviivalla (_).');" onmouseout="tooltip.hide();">
+<span onmouseover="tooltip.show('Anna tehtävän nimi. Älä käytä ääkkösiä, välilyöntiä tai muita erikoismerkkejä. Korvaa välilyönnit alaviivalla (_).');"
+      onmouseout="tooltip.hide();">
     <img src="/kipamedia/help_small.png" />
-</span><input type="text" id="{{nimi.id}}"  name="{{nimi.name}}" value="{{nimi.value}}" maxlength="255" />
+</span>
+<input type="text"
+       id="{{ nimi.id }}"
+       name="{{ nimi.name }}"
+       value="{{ nimi.value }}"
+       maxlength="255" />
 <font color=red>
-<b>{{jarjestysnro.errors}}</b>
+    <b>{{ jarjestysnro.errors }}</b>
 </font>
 Järjestysnumero:*
-<span onmouseover="tooltip.show('Tehtävän numero, jota käytetään sarjassa ulkopuolella olevien vartioiden määrittämiseen');" onmouseout="tooltip.hide();">
+<span onmouseover="tooltip.show('Tehtävän numero, jota käytetään sarjassa ulkopuolella olevien vartioiden määrittämiseen');"
+      onmouseout="tooltip.hide();">
     <img src="/kipamedia/help_small.png" />
-</span><input type="text" size="6" id="{{jarjestysnro.id}}" name="{{jarjestysnro.name}}"  value="{{jarjestysnro.value}}"  />
+</span>
+<input type="text"
+       size="6"
+       id="{{ jarjestysnro.id }}"
+       name="{{ jarjestysnro.name }}"
+       value="{{ jarjestysnro.value }}" />
 <font color=red>
-<b>{{osatehtavia.errors}}</b>
+    <b>{{ osatehtavia.errors }}</b>
 </font>
 Osatehtäviä:*
-<span onmouseover="tooltip.show('Kukin tehtävä koostuu osatehtävistä ja kukin osatehtävä syötteistä. Anna osatehtävien lukumäärä.');" onmouseout="tooltip.hide();">
+<span onmouseover="tooltip.show('Kukin tehtävä koostuu osatehtävistä ja kukin osatehtävä syötteistä. Anna osatehtävien lukumäärä.');"
+      onmouseout="tooltip.hide();">
     <img src="/kipamedia/help_small.png" />
-</span><input type="text" size="6" id="{{osatehtavia.id}}" name="{{osatehtavia.name}}" value="{{osatehtavia.value}}" />
+</span>
+<input type="text"
+       size="6"
+       id="{{ osatehtavia.id }}"
+       name="{{ osatehtavia.name }}"
+       value="{{ osatehtavia.value }}" />
 <font color=red>
-<b>{{lyhenne.errors}}</b>
+    <b>{{ lyhenne.errors }}</b>
 </font>
 Lyhenne:
-<span onmouseover="tooltip.show('Anna tässä lyhenne, jolla tehtävä näkyy tuloksissa.');" onmouseout="tooltip.hide();"><img src="/kipamedia/help_small.png" />
-</span><input type="text" size="6" id="{{lyhenne.id}}" name="{{lyhenne.name}}" value="{{lyhenne.value}}" />
-
-
+<span onmouseover="tooltip.show('Anna tässä lyhenne, jolla tehtävä näkyy tuloksissa.');"
+      onmouseout="tooltip.hide();">
+    <img src="/kipamedia/help_small.png" />
+</span>
+<input type="text"
+       size="6"
+       id="{{ lyhenne.id }}"
+       name="{{ lyhenne.name }}"
+       value="{{ lyhenne.value }}" />
 <font color=red>
-    <b>{{maksimipisteet.errors}}</b>
+    <b>{{ maksimipisteet.errors }}</b>
 </font>
 Maksimipisteet:
-<span onmouseover="tooltip.show('Tehtävän maksimipisteet. Ei vaikutusta laskentaan. Näkyvät infona tuloksissa.');" onmouseout="tooltip.hide();">
+<span onmouseover="tooltip.show('Tehtävän maksimipisteet. Ei vaikutusta laskentaan. Näkyvät infona tuloksissa.');"
+      onmouseout="tooltip.hide();">
     <img src="/kipamedia/help_small.png" />
-</span><input type="text" size="6" id="{{maksimipisteet.id}}" name="{{maksimipisteet.name}}" value="{{maksimipisteet.value}}" />
-
+</span>
+<input type="text"
+       size="6"
+       id="{{ maksimipisteet.id }}"
+       name="{{ maksimipisteet.name }}"
+       value="{{ maksimipisteet.value }}" />
 <br>
 <font color=red>
-<b>{{kaava.errors}}</b>
+    <b>{{ kaava.errors }}</b>
 </font>
 Kaava:*
-<span onmouseover="tooltip.show('Anna tässä kaava, jolla osatehtävien pisteistä lasketaan tehtävästä jaettavat pisteet. Esim. \'ss\' (suora summa, eli osatehtävistä saatavat pisteet lasketaan yhteen) tai \'a+b(c*d)\'');" onmouseout="tooltip.hide();">
+<span onmouseover="tooltip.show('Anna tässä kaava, jolla osatehtävien pisteistä lasketaan tehtävästä jaettavat pisteet. Esim. \'ss\' (suora summa, eli osatehtävistä saatavat pisteet lasketaan yhteen) tai \'a+b(c*d)\'');"
+      onmouseout="tooltip.hide();">
     <img src="/kipamedia/help_small.png" />
-</span> <input type="text" size="100" id="{{kaava.id}}" name="{{kaava.name}}" value="{{kaava.value}}" />
-<a href="/kipa/{{kisa_nimi}}/maarita/vaiheet/{{tehtava_id}}/"> Laskennan välivaiheet </a>
-
-
+</span>
+<input type="text"
+       size="100"
+       id="{{ kaava.id }}"
+       name="{{ kaava.name }}"
+       value="{{ kaava.value }}" />
+<a href="/kipa/{{ kisa_nimi }}/maarita/vaiheet/{{ tehtava_id }}/">Laskennan välivaiheet</a>
 <br>
 <font color=red>
-<b>{{rastikasky.errors}}</b>
+    <b>{{ rastikasky.errors }}</b>
 </font>
 Rastikäskylinkki:
-<span onmouseover="tooltip.show('Anna www-linkki rastikäskytiedostoon tai rastikäskytiedoston polku paikallisella levyllä. Linkki muodostuu tulostettavan tulosliuskan tehtävien nimiin. Toimintoa voidaan käyttää esim. laitettaessa tulokset nettiin ja haluttaessa linkittää Kiskan rastikäskyt suoraan tulosliuskoihin.');" onmouseout="tooltip.hide();">
-        <img src="/kipamedia/help_small.png" />
-</span><input type="text" size="50" id="{{rastikasky.id}}"  name="{{rastikasky.name}}" value="{{rastikasky.value}}" maxlength="255" />
-
-{% for form in osa_tehtavat %}
-        {{ form }}
-{% endfor %}
-
-{{osatehtavat}}
-
-
+<span onmouseover="tooltip.show('Anna www-linkki rastikäskytiedostoon tai rastikäskytiedoston polku paikallisella levyllä. Linkki muodostuu tulostettavan tulosliuskan tehtävien nimiin. Toimintoa voidaan käyttää esim. laitettaessa tulokset nettiin ja haluttaessa linkittää Kiskan rastikäskyt suoraan tulosliuskoihin.');"
+      onmouseout="tooltip.hide();">
+    <img src="/kipamedia/help_small.png" />
+</span>
+<input type="text"
+       size="50"
+       id="{{ rastikasky.id }}"
+       name="{{ rastikasky.name }}"
+       value="{{ rastikasky.value }}"
+       maxlength="255" />
+{% for form in osa_tehtavat %}{{ form }}{% endfor %}
+{{ osatehtavat }}

--- a/web/templates/tupa/forms/tehtava.html
+++ b/web/templates/tupa/forms/tehtava.html
@@ -1,45 +1,45 @@
 
-<font color=red><b>
-{{nimi.errors}}
-</b></font>
+<font color=red>
+<b>{{nimi.errors}}</b>
+</font>
 Nimi:*
 <span onmouseover="tooltip.show('Anna tehtävän nimi. Älä käytä ääkkösiä, välilyöntiä tai muita erikoismerkkejä. Korvaa välilyönnit alaviivalla (_).');" onmouseout="tooltip.hide();">
     <img src="/kipamedia/help_small.png" />
 </span><input type="text" id="{{nimi.id}}"  name="{{nimi.name}}" value="{{nimi.value}}" maxlength="255" />
-<font color=red><b>
-{{jarjestysnro.errors}}
-</b></font>
+<font color=red>
+<b>{{jarjestysnro.errors}}</b>
+</font>
 Järjestysnumero:*
 <span onmouseover="tooltip.show('Tehtävän numero, jota käytetään sarjassa ulkopuolella olevien vartioiden määrittämiseen');" onmouseout="tooltip.hide();">
     <img src="/kipamedia/help_small.png" />
 </span><input type="text" size="6" id="{{jarjestysnro.id}}" name="{{jarjestysnro.name}}"  value="{{jarjestysnro.value}}"  />
-<font color=red><b>
-{{osatehtavia.errors}}
-</b></font>
+<font color=red>
+<b>{{osatehtavia.errors}}</b>
+</font>
 Osatehtäviä:*
 <span onmouseover="tooltip.show('Kukin tehtävä koostuu osatehtävistä ja kukin osatehtävä syötteistä. Anna osatehtävien lukumäärä.');" onmouseout="tooltip.hide();">
     <img src="/kipamedia/help_small.png" />
 </span><input type="text" size="6" id="{{osatehtavia.id}}" name="{{osatehtavia.name}}" value="{{osatehtavia.value}}" />
-<font color=red><b>
-{{lyhenne.errors}}
-</b></font>
+<font color=red>
+<b>{{lyhenne.errors}}</b>
+</font>
 Lyhenne:
 <span onmouseover="tooltip.show('Anna tässä lyhenne, jolla tehtävä näkyy tuloksissa.');" onmouseout="tooltip.hide();"><img src="/kipamedia/help_small.png" />
 </span><input type="text" size="6" id="{{lyhenne.id}}" name="{{lyhenne.name}}" value="{{lyhenne.value}}" />
 
 
-<font color=red><b>
-{{maksimipisteet.errors}}
-</b></font>
+<font color=red>
+    <b>{{maksimipisteet.errors}}</b>
+</font>
 Maksimipisteet:
 <span onmouseover="tooltip.show('Tehtävän maksimipisteet. Ei vaikutusta laskentaan. Näkyvät infona tuloksissa.');" onmouseout="tooltip.hide();">
     <img src="/kipamedia/help_small.png" />
 </span><input type="text" size="6" id="{{maksimipisteet.id}}" name="{{maksimipisteet.name}}" value="{{maksimipisteet.value}}" />
 
 <br>
-<font color=red><b>
-{{kaava.errors}}
-</b></font>
+<font color=red>
+<b>{{kaava.errors}}</b>
+</font>
 Kaava:*
 <span onmouseover="tooltip.show('Anna tässä kaava, jolla osatehtävien pisteistä lasketaan tehtävästä jaettavat pisteet. Esim. \'ss\' (suora summa, eli osatehtävistä saatavat pisteet lasketaan yhteen) tai \'a+b(c*d)\'');" onmouseout="tooltip.hide();">
     <img src="/kipamedia/help_small.png" />
@@ -48,9 +48,9 @@ Kaava:*
 
 
 <br>
-<font color=red><b>
-{{rastikasky.errors}}
-</b></font>
+<font color=red>
+<b>{{rastikasky.errors}}</b>
+</font>
 Rastikäskylinkki:
 <span onmouseover="tooltip.show('Anna www-linkki rastikäskytiedostoon tai rastikäskytiedoston polku paikallisella levyllä. Linkki muodostuu tulostettavan tulosliuskan tehtävien nimiin. Toimintoa voidaan käyttää esim. laitettaessa tulokset nettiin ja haluttaessa linkittää Kiskan rastikäskyt suoraan tulosliuskoihin.');" onmouseout="tooltip.hide();">
         <img src="/kipamedia/help_small.png" />

--- a/web/templates/tupa/forms/tulostaulu.html
+++ b/web/templates/tupa/forms/tulostaulu.html
@@ -1,2 +1,5 @@
-<input type="text" id="{{id}}" name="{{name}}" value="{{value}}" size="4"/>
-
+<input type="text"
+       id="{{ id }}"
+       name="{{ name }}"
+       value="{{ value }}"
+       size="4" />

--- a/web/templates/tupa/forms/vapaa_kaava.html
+++ b/web/templates/tupa/forms/vapaa_kaava.html
@@ -1,47 +1,52 @@
-
-<b>Syötteet:</b><br>
+<b>Syötteet:</b>
+<br>
 <table>
-{% for maarite in maaritteet %}
-    <tr>
-        <td>Syötteen {{maarite.nimi}} kuvaus:</td>
-        <td>
-            <input type="text"
-                    name="{{maarite.kali_vihje.name}}"
-                    id="{{maarite.kali_vihje.id}}"
-                    value="{{maarite.kali_vihje.value}}" />
-            Tyyppi:
-
-            <select name="{{maarite.tyyppi.name}}">
-                <option value="piste"
-                {% if maarite.tyyppi.value == "piste" %}selected="selected"{% endif %}
-                 >piste</option>
-                <option value="aika"
-                {% if maarite.tyyppi.value == "aika" %}selected="selected"{% endif %}
-                >aika</option>
-            </select>
-        </td>
-    </tr>
-{% endfor %}
+    {% for maarite in maaritteet %}
+        <tr>
+            <td>Syötteen {{ maarite.nimi }} kuvaus:</td>
+            <td>
+                <input type="text"
+                       name="{{ maarite.kali_vihje.name }}"
+                       id="{{ maarite.kali_vihje.id }}"
+                       value="{{ maarite.kali_vihje.value }}" />
+                Tyyppi:
+                <select name="{{ maarite.tyyppi.name }}">
+                    <option value="piste"
+                            {% if maarite.tyyppi.value == "piste" %}selected="selected"{% endif %}>piste</option>
+                    <option value="aika"
+                            {% if maarite.tyyppi.value == "aika" %}selected="selected"{% endif %}>aika</option>
+                </select>
+            </td>
+        </tr>
+    {% endfor %}
 </table>
-
-<button name="lisaa_maaritteita" type="submit" class="small blue awesome" value='{{maaritteita.name}}' title="Lisää 5 tyhjää kenttää">Lisää 5 kenttää</button><br><br>
-
-<font color=red><b>{{kaava.errors}}</b></font> Vartion suorituksen kaava:
-<span onmouseover="tooltip.show('Tähän tulee kaava, jolla lasketaan yksittäisen vartion suoritus osatehtävässä. Syötteisiin viitataan niiden kirjaimilla. Aikaa käsitellään laskennallisesti sekunteina.' );" onmouseout="tooltip.hide();"><img src="/kipamedia/help_small.png" />
-
-Funktiot: {% include "tupa/forms/funktiot_apu.html" %} Operaattorit: {% include "tupa/forms/operaattorit_apu.html" %}
+<button name="lisaa_maaritteita"
+        type="submit"
+        class="small blue awesome"
+        value='{{ maaritteita.name }}'
+        title="Lisää 5 tyhjää kenttää">Lisää 5 kenttää</button>
+<br>
+<br>
+<font color=red><b>{{ kaava.errors }}</b></font> Vartion suorituksen kaava:
+<span onmouseover="tooltip.show('Tähän tulee kaava, jolla lasketaan yksittäisen vartion suoritus osatehtävässä. Syötteisiin viitataan niiden kirjaimilla. Aikaa käsitellään laskennallisesti sekunteina.' );"
+      onmouseout="tooltip.hide();">
+    <img src="/kipamedia/help_small.png" />
+    Funktiot:
+    {% include "tupa/forms/funktiot_apu.html" %}
+    Operaattorit:
+    {% include "tupa/forms/operaattorit_apu.html" %}
 </span>
-
 <input type="text"
-                        name="{{kaava.name}}"
-                        id="{{kaava.id}}"
-                        value="{{kaava.value}}" style="width:100%;" /><br />
-<br><br>
-
+       name="{{ kaava.name }}"
+       id="{{ kaava.id }}"
+       value="{{ kaava.value }}"
+       style="width:100%" />
+<br />
+<br>
+<br>
 {% include "tupa/forms/maksimi_suoritus.html" %}
 {% include "tupa/forms/nolla_suoritus.html" %}
 {% include "tupa/forms/arviointi.html" %}
-
-<INPUT TYPE=HIDDEN NAME="{{maaritteita.name}}" value="{{maaritteita.value}}">
-
-
+<input TYPE="HIDDEN"
+       NAME="{{ maaritteita.name }}"
+       value="{{ maaritteita.value }}">

--- a/web/templates/tupa/heijasta.html
+++ b/web/templates/tupa/heijasta.html
@@ -9,28 +9,6 @@
 <title>Sarjakohtaiset tulokset</title>
 <link href="/kipamedia/favicon.ico" rel="icon" type="image/x-icon" />
 <style type="text/css">
-<!--
-BODY {
-Size: A4 landscape;
-    FONT-SIZE: 20px;
-    LINE-HEIGHT: 120%;
-    FONT-FAMILY: Tahoma, Verdana, Arial, Helvetica, sans-serif;
-    BACKGROUND-COLOR: white;
-    margin-top: 5px;
-    margin-left: 5px;
-}
-TD {
-    FONT-SIZE: 20px;
-    vertical-align:top;
-}
-
-@page figures {
-    size: landscape
-}
-
-.capitalize {text-transform:capitalize;}
-.uppercase  {text-transform:uppercase;}
--->
 </style>
 
 

--- a/web/templates/tupa/heijasta.html
+++ b/web/templates/tupa/heijasta.html
@@ -53,9 +53,9 @@
                                         {% comment %} ylarivi {% endcomment %}
 
                                         {% if sarake.jarjestysnro %}
-                                        <td align="right" width=30 style="padding-right:10px;"><b>
-                                                {{ sarake.jarjestysnro }}.
-                                        </b></td>
+                                        <td align="right" width=30 style="padding-right:10px;">
+                                            <b>{{ sarake.jarjestysnro }}.</b>
+                                        </td>
                                         {% endif %}
                                 {% endif %}
                 {% endfor %}

--- a/web/templates/tupa/heijasta.html
+++ b/web/templates/tupa/heijasta.html
@@ -1,200 +1,234 @@
-﻿<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-{% block header %}
-{% if vaihtoaika %}
-<meta http-equiv="refresh" content="{{vaihtoaika}};url=/kipa/{{kisa_nimi}}/tulosta/heijasta/sarja/{{vaihto_id}}/">
-{% endif %}
-{% endblock header %}
-<title>Sarjakohtaiset tulokset</title>
-<link href="/kipamedia/favicon.ico" rel="icon" type="image/x-icon" />
-<style type="text/css">
-</style>
-
-
-</head>
-<body>
-{% load kipatags %}
-
-<table width="100%" border="0" id="tulostaulukko_otsikko">
-<tr valign="top">
-    <td width="33%"><h1 class="uppercase" style="margin:0; padding:0; line-height:normal;">{{kisa_nimi|alaviiva_pois}}</h1></td>
-    <td width="33%" align="center"><h2 style="line-height:normal;">{{heading}}</h2></td>
-    <td width="33%" align="right">&nbsp;</td>
-</tr>
-<tr>
-    <td>{%if kisa_aika %}
-            {{kisa_aika}}<br>
-        {% endif %}
-        {{kisa_paikka}}
-    </td>
-    <td align="center">{% now "j.n.Y G:i"%}</td>
-    <td align="center">&nbsp;</td>
-</tr>
-</table>
-
-{% if tulos_taulukko %}
-    <table id="tulostaulukko_screen" border=0 >
-        {% for rivi in tulos_taulukko%}
-                {%if forloop.counter|add:"3"|divisibleby:"5" %}
-                        <tr height="10"><td></td></tr>
-                {% endif %}
-                {% if forloop.first %}
-                      <tr>
-                {% for sarake in rivi %}
-                     {% comment %} ylarivi {% endcomment %}
-                                {% if forloop.first  %}
-                                        {% comment %} ylarivin eka {% endcomment %}
-                                        <td width="30" align="right"></td>
-                                        <td width="30" align="right" style="padding-right:10px;"><b></b></td>
-                                        <td style="min-width:100px;"></td>
-                                        <td align="right" width=30 style="padding-right:10px;"></td>
+﻿
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        {% block header %}
+            {% if vaihtoaika %}
+                <meta http-equiv="refresh"
+                      content="{{ vaihtoaika }};url=/kipa/{{ kisa_nimi }}/tulosta/heijasta/sarja/{{ vaihto_id }}/">
+            {% endif %}
+        {% endblock header %}
+        <title>Sarjakohtaiset tulokset</title>
+        <link href="/kipamedia/favicon.ico" rel="icon" type="image/x-icon" />
+        <style type="text/css"></style>
+    </head>
+    <body>
+        {% load kipatags %}
+        <table width="100%" border="0" id="tulostaulukko_otsikko">
+            <tr valign="top">
+                <td width="33%">
+                    <h1 class="uppercase" style="margin:0; padding:0; line-height:normal;">{{ kisa_nimi|alaviiva_pois }}</h1>
+                </td>
+                <td width="33%" align="center">
+                    <h2 style="line-height:normal;">{{ heading }}</h2>
+                </td>
+                <td width="33%" align="right">&nbsp;</td>
+            </tr>
+            <tr>
+                <td>
+                    {% if kisa_aika %}
+                        {{ kisa_aika }}
+                        <br>
+                    {% endif %}
+                    {{ kisa_paikka }}
+                </td>
+                <td align="center">{% now "j.n.Y G:i" %}</td>
+                <td align="center">&nbsp;</td>
+            </tr>
+        </table>
+        {% if tulos_taulukko %}
+            <table id="tulostaulukko_screen" border=0>
+                {% for rivi in tulos_taulukko %}
+                    {% if forloop.counter|add:"3"|divisibleby:"5" %}
+                        <tr height="10">
+                            <td></td>
+                        </tr>
+                    {% endif %}
+                    {% if forloop.first %}
+                        <tr>
+                            {% for sarake in rivi %}
+                                {% comment %} ylarivi {% endcomment %}
+                                {% if forloop.first %}
+                                    {% comment %} ylarivin eka {% endcomment %}
+                                    <td width="30" align="right"></td>
+                                    <td width="30" align="right" style="padding-right:10px;">
+                                        <b></b>
+                                    </td>
+                                    <td style="min-width:100px;"></td>
+                                    <td align="right" width=30 style="padding-right:10px;"></td>
                                 {% else %}
-                                        {% comment %} ylarivi {% endcomment %}
-
-                                        {% if sarake.jarjestysnro %}
+                                    {% comment %} ylarivi {% endcomment %}
+                                    {% if sarake.jarjestysnro %}
                                         <td align="right" width=30 style="padding-right:10px;">
                                             <b>{{ sarake.jarjestysnro }}.</b>
                                         </td>
-                                        {% endif %}
+                                    {% endif %}
                                 {% endif %}
-                {% endfor %}
-
-                      </tr>
-                      <tr valign="top">
-
-                        <td></td>
-                        {% for sarake in rivi %}
-                     {% comment %} ylarivi {% endcomment %}
-                                {% if forloop.first  %}
-                                        {% comment %} ylarivin eka {% endcomment %}
-                                        <td></td> <td></td>
-                                {% else %}
-                                        {% comment %} ylarivi {% endcomment %}
-                                        {%if sarake.lyhenne %}
-                                        <td align="right" style="padding-right:10px;"><b>{{sarake.lyhenne}}</b></td>
-                                        {% else %}
-                                        <td align="right" width="60" style="padding-right:10px;"><b>
-                                            {{sarake.nimi|slice:":6"}}<br />
-                                            {{sarake.nimi|slice:"6:13"}}<br />
-                                            {{sarake.nimi|slice:"13:19"}}<br />
-                                            {{sarake.nimi|slice:"19:25"}}</b>
-                                        </td>
-                                        {% endif %}
-                                {% endif %}
-                        {%endfor %}
-
-                      </tr>
-                      <tr>
-                      <td></td><td></td><td align="right"><em>Maxpisteet</em></td>
-                        {% for sarake in rivi %}
-                                {% if forloop.first  %}
-                               <td align="right" style="padding-right:10px;"><em> {{ sarake.maksimipisteet }} </em></td>
-                                {% else %}
-
-                                {% if forloop.counter != 0 %}
-                                {% if forloop.counter != 1 %}
-                                {% if forloop.counter != 2 %}
-                                        <td align="right" style="padding-right:10px;"><em> {{ sarake.maksimipisteet }} </em></td>
-                                {% endif %}
-                                {% endif %}
-                                {% endif %}
-                                {% endif %}
-
-                        {%endfor %}
-                      </tr>
-                      <tr>
-                            <td width="30" align="right"><b>SIJ.</b></td>
-                            <td width="30" align="right" style="padding-right:10px;"><b></b></td>
-                            <td style="min-width:100px;"><b>VARTIO</b></td>
-                            <td align="right" width=30 style="padding-right:10px;"><b>YHT</b></td>
-                      </tr>
-
-                      <tr valign='top'>
-
-                {% else %}
-                {% for sarake in rivi %}
-                     {% comment %} ylarivi {% endcomment %}
-                     {% if forloop.counter == 2 %}
-                     {% comment %} ekasarake {% endcomment %}
-                        <td align="right" style="padding-right:10px;"> {{ sarake.nro }}</td> <td>{{sarake.nimi}}
-                                                {%if sarake.lippukunta %}<br>{%endif%}
-                                                {{sarake.lippukunta}}
-                                                {%if sarake.piiri %}<br>{%endif%}
-                                                {{sarake.piiri}}</td>
-                     {% else %}
-                     {% if forloop.counter == 3 %}
-                        <td align="right" style="padding-right:10px;">{{sarake}}</td>
-                     {% comment %} muut sarakkeet {% endcomment %}
-                     {% else %}
-                        <td align="right" style="padding-right:10px;">
-                                {% if forloop.first %} <b> {%endif%}
-                                        {{ sarake }}
-                                {% if forloop.first %} </b> {%endif%}
-                        </td>
-                     {% endif %}
-                     {% endif %}
-
-                {% endfor %}
-                     {% endif %}
-            </tr>
-               {% comment %} ULKONA OLEVAT: {% endcomment %}
-                {% if forloop.last %}
-                        <tr><td>&nbsp;  </td></tr>
-                        <tr><td> </td> <td></td><td><b>Ulkopuolella:</b> </td></tr>
-                        {% for rivi in ulkona_taulukko%}
-                        <tr valign='top'>
-                        {% for sarake in rivi %}
-
-
-                                {% if forloop.counter == 2 %}
-                                        {% comment %} ekasarake {% endcomment %}
-                                        <td align="right" style="padding-right:10px;">{{ sarake.nro }}</td> <td>{{ sarake.nimi }}
-                                                {%if sarake.lippukunta %}<br>{%endif%}
-                                                {{sarake.lippukunta}}
-                                                {%if sarake.piiri %}<br> {%endif%}
-                                                {{sarake.piiri}} </td>
-
-                                {% else %}
-                                        {% comment %} muut sarakkeet {% endcomment %}
-                                <td align="right" style="padding-right:10px;">
-                                        {% if forloop.first %} <b> {%endif%}
-                                        {{ sarake }}
-                                        {% if forloop.first %} </b> {%endif%}
-                                </td>
-                                {% endif %}
-                        {% endfor %}
+                            {% endfor %}
                         </tr>
-                        {%if forloop.counter|divisibleby:"5" %}
-                                        <tr height=10><td></td></tr>
+                        <tr valign="top">
+                            <td></td>
+                            {% for sarake in rivi %}
+                                {% comment %} ylarivi {% endcomment %}
+                                {% if forloop.first %}
+                                    {% comment %} ylarivin eka {% endcomment %}
+                                    <td></td>
+                                    <td></td>
+                                {% else %}
+                                    {% comment %} ylarivi {% endcomment %}
+                                    {% if sarake.lyhenne %}
+                                        <td align="right" style="padding-right:10px;">
+                                            <b>{{ sarake.lyhenne }}</b>
+                                        </td>
+                                    {% else %}
+                                        <td align="right" width="60" style="padding-right:10px;">
+                                            <b>
+                                                {{ sarake.nimi|slice:":6" }}
+                                                <br />
+                                                {{ sarake.nimi|slice:"6:13" }}
+                                                <br />
+                                                {{ sarake.nimi|slice:"13:19" }}
+                                                <br />
+                                            {{ sarake.nimi|slice:"19:25" }}</b>
+                                        </td>
+                                    {% endif %}
+                                {% endif %}
+                            {% endfor %}
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td></td>
+                            <td align="right">
+                                <em>Maxpisteet</em>
+                            </td>
+                            {% for sarake in rivi %}
+                                {% if forloop.first %}
+                                    <td align="right" style="padding-right:10px;">
+                                        <em>{{ sarake.maksimipisteet }}</em>
+                                    </td>
+                                {% else %}
+                                    {% if forloop.counter != 0 %}
+                                        {% if forloop.counter != 1 %}
+                                            {% if forloop.counter != 2 %}
+                                                <td align="right" style="padding-right:10px;">
+                                                    <em>{{ sarake.maksimipisteet }}</em>
+                                                </td>
+                                            {% endif %}
+                                        {% endif %}
+                                    {% endif %}
+                                {% endif %}
+                            {% endfor %}
+                        </tr>
+                        <tr>
+                            <td width="30" align="right">
+                                <b>SIJ.</b>
+                            </td>
+                            <td width="30" align="right" style="padding-right:10px;">
+                                <b></b>
+                            </td>
+                            <td style="min-width:100px;">
+                                <b>VARTIO</b>
+                            </td>
+                            <td align="right" width=30 style="padding-right:10px;">
+                                <b>YHT</b>
+                            </td>
+                        </tr>
+                        <tr valign='top'>
+                        {% else %}
+                            {% for sarake in rivi %}
+                                {% comment %} ylarivi {% endcomment %}
+                                {% if forloop.counter == 2 %}
+                                    {% comment %} ekasarake {% endcomment %}
+                                    <td align="right" style="padding-right:10px;">{{ sarake.nro }}</td>
+                                    <td>
+                                        {{ sarake.nimi }}
+                                        {% if sarake.lippukunta %}<br>{% endif %}
+                                        {{ sarake.lippukunta }}
+                                        {% if sarake.piiri %}<br>{% endif %}
+                                        {{ sarake.piiri }}
+                                    </td>
+                                {% else %}
+                                    {% if forloop.counter == 3 %}
+                                        <td align="right" style="padding-right:10px;">{{ sarake }}</td>
+                                        {% comment %} muut sarakkeet {% endcomment %}
+                                    {% else %}
+                                        <td align="right" style="padding-right:10px;">
+                                            {% if forloop.first %}<b>{% endif %}
+                                                {{ sarake }}
+                                                {% if forloop.first %}</b>{% endif %}
+                                        </td>
+                                    {% endif %}
+                                {% endif %}
+                            {% endfor %}
                         {% endif %}
+                    </tr>
+                    {% comment %} ULKONA OLEVAT: {% endcomment %}
+                    {% if forloop.last %}
+                        <tr>
+                            <td>&nbsp;</td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td></td>
+                            <td>
+                                <b>Ulkopuolella:</b>
+                            </td>
+                        </tr>
+                        {% for rivi in ulkona_taulukko %}
+                            <tr valign='top'>
+                                {% for sarake in rivi %}
+                                    {% if forloop.counter == 2 %}
+                                        {% comment %} ekasarake {% endcomment %}
+                                        <td align="right" style="padding-right:10px;">{{ sarake.nro }}</td>
+                                        <td>
+                                            {{ sarake.nimi }}
+                                            {% if sarake.lippukunta %}<br>{% endif %}
+                                            {{ sarake.lippukunta }}
+                                            {% if sarake.piiri %}<br>{% endif %}
+                                            {{ sarake.piiri }}
+                                        </td>
+                                    {% else %}
+                                        {% comment %} muut sarakkeet {% endcomment %}
+                                        <td align="right" style="padding-right:10px;">
+                                            {% if forloop.first %}<b>{% endif %}
+                                                {{ sarake }}
+                                                {% if forloop.first %}</b>{% endif %}
+                                        </td>
+                                    {% endif %}
+                                {% endfor %}
+                            </tr>
+                            {% if forloop.counter|divisibleby:"5" %}
+                                <tr height=10>
+                                    <td></td>
+                                </tr>
+                            {% endif %}
                         {% endfor %}
-                {% endif %}
-        {% endfor %}
-
-        <tr>
-        <br>
-        <br>
-        </tr>
-
-
-    </table>
-
-{% else %}
-    <p>Ei tuloksia.</p>
-{% endif %}
-
-<p><font size=2>
- S = syöttämättä<br>
- H = vartion suoritus hylätty<br>
- K = vartio keskeyttänyt<br>
- E = vartio ei ole tehnyt tehtävää<br>
- ! = vartion sijaluku laskettu tasapisteissä määräävien tehtävien perusteella<br>
-</font>
-
-</p>
-<p><a href="/kipa/{{kisa_nimi}}/">Takaisin etusivulle</a></p>
-
-</body>
-
+                    {% endif %}
+                {% endfor %}
+                <tr>
+                    <br>
+                    <br>
+                </tr>
+            </table>
+        {% else %}
+            <p>Ei tuloksia.</p>
+        {% endif %}
+        <p>
+            <font size=2>
+                S = syöttämättä
+                <br>
+                H = vartion suoritus hylätty
+                <br>
+                K = vartio keskeyttänyt
+                <br>
+                E = vartio ei ole tehnyt tehtävää
+                <br>
+                ! = vartion sijaluku laskettu tasapisteissä määräävien tehtävien perusteella
+                <br>
+            </font>
+        </p>
+        <p>
+            <a href="/kipa/{{ kisa_nimi }}/">Takaisin etusivulle</a>
+        </p>
+    </body>
 </html>

--- a/web/templates/tupa/index.html
+++ b/web/templates/tupa/index.html
@@ -15,7 +15,7 @@
         <div style="float:right; margin-top:-4px; margin-bottom:0; padding-bottom:0; height:18px;">
             {% include "tupa/login.html" %}
         </div>
-    </div><!-- /header -->
+    </div>
     <div id="breadcrumbs"></div>
 
     <div id="main" class="clearfix">
@@ -38,10 +38,10 @@
             <p><a href='lisaaKisa/'> Lisää kisa tiedostosta</a><br></p>
         </blockquote>
 
-            </div><!-- /right -->
-        </div><!-- /container -->
-    </div><!-- /main -->
-</div><!-- /wrap -->
+            </div>
+        </div>
+    </div>
+</div>
 
 <div id="footer">Kipa</div>
 

--- a/web/templates/tupa/index.html
+++ b/web/templates/tupa/index.html
@@ -1,49 +1,51 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Kipa - kaikki kisat</title>
-<link rel="stylesheet" type="text/css" href="/kipamedia/kipa.css" />
-<link rel="stylesheet" type="text/css" href="/kipamedia/tabcontent.css" />
-<link rel="icon" type="image/x-icon" href="/kipamedia/favicon.ico" />
-</head>
-<body>
-
-{% include "tupa/vaara_tietokanta.html" %}
-
-<div id="wrap">
-    <div id="header"><div id="pageTitle">{{kisa_nimi}} <font color=00FF00 size=3><b>{{talletettu}}</b></font></div>
-        <div style="float:right; margin-top:-4px; margin-bottom:0; padding-bottom:0; height:18px;">
-            {% include "tupa/login.html" %}
-        </div>
-    </div>
-    <div id="breadcrumbs"></div>
-
-    <div id="main" class="clearfix">
-
-        <div id="container">
-            <div id="right" class="column">
-
-        <h1>Kisat</h1>
-        <blockquote>
-            {% if object_list %}
-                {% for kisa in object_list %}
-                <a href='{{kisa.nimi}}/' > {{kisa.nimi}} </a> <br>
-                {% endfor %}
-
-            {% else %}
-                <p>Ei määriteltyjä kisoja.</p>
-            {% endif %}
-
-            <p><a href='uusiKisa/maarita/'>Luo uusi kisa</a><br></p>
-            <p><a href='lisaaKisa/'> Lisää kisa tiedostosta</a><br></p>
-        </blockquote>
-
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>Kipa - kaikki kisat</title>
+        <link rel="stylesheet" type="text/css" href="/kipamedia/kipa.css" />
+        <link rel="stylesheet" type="text/css" href="/kipamedia/tabcontent.css" />
+        <link rel="icon" type="image/x-icon" href="/kipamedia/favicon.ico" />
+    </head>
+    <body>
+        {% include "tupa/vaara_tietokanta.html" %}
+        <div id="wrap">
+            <div id="header">
+                <div id="pageTitle">
+                    {{ kisa_nimi }} <font color=00FF00 size=3><b>{{ talletettu }}</b></font>
+                </div>
+                <div style="float:right;
+                            margin-top:-4px;
+                            margin-bottom:0;
+                            padding-bottom:0;
+                            height:18px">{% include "tupa/login.html" %}</div>
+            </div>
+            <div id="breadcrumbs"></div>
+            <div id="main" class="clearfix">
+                <div id="container">
+                    <div id="right" class="column">
+                        <h1>Kisat</h1>
+                        <blockquote>
+                            {% if object_list %}
+                                {% for kisa in object_list %}
+                                    <a href='{{ kisa.nimi }}/'>{{ kisa.nimi }}</a>
+                                    <br>
+                                {% endfor %}
+                            {% else %}
+                                <p>Ei määriteltyjä kisoja.</p>
+                            {% endif %}
+                            <p>
+                                <a href='uusiKisa/maarita/'>Luo uusi kisa</a>
+                                <br>
+                            </p>
+                            <p>
+                                <a href='lisaaKisa/'>Lisää kisa tiedostosta</a>
+                                <br>
+                            </p>
+                        </blockquote>
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
-</div>
-
-<div id="footer">Kipa</div>
-
-</body>
+        <div id="footer">Kipa</div>
+    </body>
 </html>

--- a/web/templates/tupa/kisa.html
+++ b/web/templates/tupa/kisa.html
@@ -1,90 +1,143 @@
 {% extends "tupa/base.html" %}
-
-{% block title %}{{kisa.nimi}}{% endblock %}
-
+{% block title %}{{ kisa.nimi }}{% endblock %}
 {% block content %}
-
-
-
-<table width="960" border="0" align="center" cellpadding="5" cellspacing="20" id="etusivu">
-
-  <tr>
-
-    <td valign="top" width="360" class="etusivuloota">
-
-    <p class="etusivunOtsikko"><img src="/kipamedia/plus.png" width="64" height="64" />Suoritusten syöttö</p>
-
-    <p class="etusivunLinkit"><a href="./syota/"><span onmouseover="tooltip.show('Syötä vartioiden suorituksia');" onmouseout="tooltip.hide();">syötä suorituksia</span></a></p>
-
-    <p class="etusivunLinkit"><a href="./syota/tarkistus/"><span onmouseover="tooltip.show('Jos kisan suoritukset syötetään tarkistuksen vuoksi kahteen kertaan, syötä tarkistustulokset tästä');" onmouseout="tooltip.hide();">syötä suorituksia - tarkistus</span></a></p>
-
-    <p class="etusivunLinkit"><a href="maarita/tuomarineuvos/"><span onmouseover="tooltip.show('Korvaa laskettu tulos määrätyllä tuloksella');" onmouseout="tooltip.hide();">tuomarineuvoston työkalu</span></a></p></td>
-
-    <td valign="top" width="350" class="etusivuloota">
-
-    <p class="etusivunOtsikko"><img src="/kipamedia/wizard.png" width="64" height="64" />Tulokset</p>
-
-    <p class="etusivunLinkit"><a href="./tulosta/normaali/"><span onmouseover="tooltip.show('Tarkastele tuloksia sarjoittain');" onmouseout="tooltip.hide();">sarjan tulokset</span></a></p>
-
-    <p class="etusivunLinkit"><a href="./tulosta/tuloste/"><span onmouseover="tooltip.show('Tulosta tuloksia paperille');" onmouseout="tooltip.hide();">tulosta tuloksia</span></a></p>
-
-    <p class="etusivunLinkit"><a href="./tulosta/csv/"><span onmouseover="tooltip.show('Tallenna tulokset CSV-tiedostoon');" onmouseout="tooltip.hide();">tulokset CSV-tiedostoon</span></a></p>
-
-    <p class="etusivunLinkit"><a href="./tulosta/heijasta/"><span onmouseover="tooltip.show('Näytä tulokset videotykkimuodossa');" onmouseout="tooltip.hide();">heijasta tuloksia</span></a></p>
-
-    <p class="etusivunLinkit"><a href="./tulosta/tilanne/"><span onmouseover="tooltip.show('Näytä laskennan tila tällä hetkellä');" onmouseout="tooltip.hide();">laskennan tilanne</span></a></p><br></td>
-
-
-    <td align="center" width="250" valign="middle">
-
-    <img src="/kipamedia/logo-2.png" alt="KIPA" width="99" height="99" /></td>
-
-  </tr>
-
-  <tr>
-
-    <td valign="top" class="etusivuloota">
-
-    <p class="etusivunOtsikko"><img src="/kipamedia/services.png" alt="" width="64" height="64" />Kisan määritykset</p>
-
-    <p class="etusivunLinkit"><a href="./maarita/">määrittele kisan perustiedot</a></p>
-
-    <p class="etusivunLinkit"><a href="./maarita/vartiot/">määrittele vartiot</a></p>
-
-    <p class="etusivunLinkit"><a href="./maarita/tehtava/">määrittele tehtävät</a></p>
-
-    <p class="etusivunLinkit"><a href="./maarita/testitulos/">määrittele testituloksia</a></p><br /></td>
-
-    <td valign="top" class="etusivuloota">
-
-    <p class="etusivunOtsikko"><img src="/kipamedia/recycle.png" alt="" width="64" height="64" />Ylläpito</p>
-
-    <p class="etusivunLinkit"><a href='../'><span onmouseover="tooltip.show('Näytä kaikki Kipan kilpailut');" onmouseout="tooltip.hide();">listaa kaikki kisat</span></a></p>
-
-    <p class="etusivunLinkit"><a href="./tallenna/"><span onmouseover="tooltip.show('Tallenna tietokannan varmuuskopio');" onmouseout="tooltip.hide();">tallenna kisa</span></a></p>
-
-    <p class="etusivunLinkit"><a href="./korvaa/"><span onmouseover="tooltip.show('Palauta tietokannan varmuuskopio');" onmouseout="tooltip.hide();">palauta kisa</span></a></p>
-
-    <p class="etusivunLinkit"><a href="./poista/"><span onmouseover="tooltip.show('Poista tämä kisa');" onmouseout="tooltip.hide();">poista kisa</span></a></p>
-
-    </td>
-
-    <td valign="top" class="etusivuloota">
-
-    <p class="etusivunOtsikko"><img src="/kipamedia/question.png" alt="" width="64" height="64" />Apua</p>
-
-    <p class="etusivunLinkit"><a href="/kipamedia/Manuaali_v03.pdf" target="help"><span onmouseover="tooltip.show('Apua kisan pystytykseen');" onmouseout="tooltip.hide();">näin pääset alkuun (PDF)</span></a></p>
-
-    </td>
-
-  </tr>
-
-</table>
-
-
-<script type="text/javascript" language="javascript" src="/kipamedia/tooltip.js"></script>
-
-
-
+    <table width="960"
+           border="0"
+           align="center"
+           cellpadding="5"
+           cellspacing="20"
+           id="etusivu">
+        <tr>
+            <td valign="top" width="360" class="etusivuloota">
+                <p class="etusivunOtsikko">
+                    <img src="/kipamedia/plus.png" width="64" height="64" />
+                    Suoritusten syöttö
+                </p>
+                <p class="etusivunLinkit">
+                    <a href="./syota/">
+                        <span onmouseover="tooltip.show('Syötä vartioiden suorituksia');"
+                              onmouseout="tooltip.hide();">syötä suorituksia</span>
+                    </a>
+                </p>
+                <p class="etusivunLinkit">
+                    <a href="./syota/tarkistus/">
+                        <span onmouseover="tooltip.show('Jos kisan suoritukset syötetään tarkistuksen vuoksi kahteen kertaan, syötä tarkistustulokset tästä');"
+                              onmouseout="tooltip.hide();">syötä suorituksia - tarkistus</span>
+                    </a>
+                </p>
+                <p class="etusivunLinkit">
+                    <a href="maarita/tuomarineuvos/">
+                        <span onmouseover="tooltip.show('Korvaa laskettu tulos määrätyllä tuloksella');"
+                              onmouseout="tooltip.hide();">tuomarineuvoston työkalu</span>
+                    </a>
+                </p>
+            </td>
+            <td valign="top" width="350" class="etusivuloota">
+                <p class="etusivunOtsikko">
+                    <img src="/kipamedia/wizard.png" width="64" height="64" />
+                    Tulokset
+                </p>
+                <p class="etusivunLinkit">
+                    <a href="./tulosta/normaali/">
+                        <span onmouseover="tooltip.show('Tarkastele tuloksia sarjoittain');"
+                              onmouseout="tooltip.hide();">sarjan tulokset</span>
+                    </a>
+                </p>
+                <p class="etusivunLinkit">
+                    <a href="./tulosta/tuloste/">
+                        <span onmouseover="tooltip.show('Tulosta tuloksia paperille');"
+                              onmouseout="tooltip.hide();">tulosta tuloksia</span>
+                    </a>
+                </p>
+                <p class="etusivunLinkit">
+                    <a href="./tulosta/csv/">
+                        <span onmouseover="tooltip.show('Tallenna tulokset CSV-tiedostoon');"
+                              onmouseout="tooltip.hide();">tulokset CSV-tiedostoon</span>
+                    </a>
+                </p>
+                <p class="etusivunLinkit">
+                    <a href="./tulosta/heijasta/">
+                        <span onmouseover="tooltip.show('Näytä tulokset videotykkimuodossa');"
+                              onmouseout="tooltip.hide();">heijasta tuloksia</span>
+                    </a>
+                </p>
+                <p class="etusivunLinkit">
+                    <a href="./tulosta/tilanne/">
+                        <span onmouseover="tooltip.show('Näytä laskennan tila tällä hetkellä');"
+                              onmouseout="tooltip.hide();">laskennan tilanne</span>
+                    </a>
+                </p>
+                <br>
+            </td>
+            <td align="center" width="250" valign="middle">
+                <img src="/kipamedia/logo-2.png" alt="KIPA" width="99" height="99" />
+            </td>
+        </tr>
+        <tr>
+            <td valign="top" class="etusivuloota">
+                <p class="etusivunOtsikko">
+                    <img src="/kipamedia/services.png" alt="" width="64" height="64" />
+                    Kisan määritykset
+                </p>
+                <p class="etusivunLinkit">
+                    <a href="./maarita/">määrittele kisan perustiedot</a>
+                </p>
+                <p class="etusivunLinkit">
+                    <a href="./maarita/vartiot/">määrittele vartiot</a>
+                </p>
+                <p class="etusivunLinkit">
+                    <a href="./maarita/tehtava/">määrittele tehtävät</a>
+                </p>
+                <p class="etusivunLinkit">
+                    <a href="./maarita/testitulos/">määrittele testituloksia</a>
+                </p>
+                <br />
+            </td>
+            <td valign="top" class="etusivuloota">
+                <p class="etusivunOtsikko">
+                    <img src="/kipamedia/recycle.png" alt="" width="64" height="64" />
+                    Ylläpito
+                </p>
+                <p class="etusivunLinkit">
+                    <a href='../'>
+                        <span onmouseover="tooltip.show('Näytä kaikki Kipan kilpailut');"
+                              onmouseout="tooltip.hide();">listaa kaikki kisat</span>
+                    </a>
+                </p>
+                <p class="etusivunLinkit">
+                    <a href="./tallenna/">
+                        <span onmouseover="tooltip.show('Tallenna tietokannan varmuuskopio');"
+                              onmouseout="tooltip.hide();">tallenna kisa</span>
+                    </a>
+                </p>
+                <p class="etusivunLinkit">
+                    <a href="./korvaa/">
+                        <span onmouseover="tooltip.show('Palauta tietokannan varmuuskopio');"
+                              onmouseout="tooltip.hide();">palauta kisa</span>
+                    </a>
+                </p>
+                <p class="etusivunLinkit">
+                    <a href="./poista/">
+                        <span onmouseover="tooltip.show('Poista tämä kisa');"
+                              onmouseout="tooltip.hide();">poista kisa</span>
+                    </a>
+                </p>
+            </td>
+            <td valign="top" class="etusivuloota">
+                <p class="etusivunOtsikko">
+                    <img src="/kipamedia/question.png" alt="" width="64" height="64" />
+                    Apua
+                </p>
+                <p class="etusivunLinkit">
+                    <a href="/kipamedia/Manuaali_v03.pdf" target="help">
+                        <span onmouseover="tooltip.show('Apua kisan pystytykseen');"
+                              onmouseout="tooltip.hide();">näin pääset alkuun (PDF)</span>
+                    </a>
+                </p>
+            </td>
+        </tr>
+    </table>
+    <script type="text/javascript"
+            language="javascript"
+            src="/kipamedia/tooltip.js"></script>
 {% endblock %}
-

--- a/web/templates/tupa/kopioi.html
+++ b/web/templates/tupa/kopioi.html
@@ -1,8 +1,14 @@
 <br>
 <table>
-<tr>
-<td width="200" align="right"><button type="button" class="small awesome" onClick="history.back();" title="Palaa edelliselle sivulle tallentamatta muutoksia">Peruuta</button></td>
-<td width="100" align="right"><button type="submit" class="small blue awesome" >Kopioi »</button></td>
-</tr>
+    <tr>
+        <td width="200" align="right">
+            <button type="button"
+                    class="small awesome"
+                    onClick="history.back();"
+                    title="Palaa edelliselle sivulle tallentamatta muutoksia">Peruuta</button>
+        </td>
+        <td width="100" align="right">
+            <button type="submit" class="small blue awesome">Kopioi »</button>
+        </td>
+    </tr>
 </table>
-

--- a/web/templates/tupa/laskennan_tilanne.html
+++ b/web/templates/tupa/laskennan_tilanne.html
@@ -1,73 +1,73 @@
-
 {% extends "tupa/base.html" %}
 {% block title %}Tulokset sarjoittain{% endblock %}
-
 {% block header %}
-<meta http-equiv="refresh" content="60" http-equiv="Content-Type" content="text/html; charset=utf-8"  />
-<title>Tulokset sarjoittain</title>
-<link href="kipa.css" rel="stylesheet" type="text/css" />
-
+    <meta http-equiv="refresh"
+          content="60"
+          http-equiv="Content-Type"
+          content="text/html; charset=utf-8" />
+    <title>Tulokset sarjoittain</title>
+    <link href="kipa.css" rel="stylesheet" type="text/css" />
 {% endblock header %}
-
 {% block content %}
-<body>
-{% load kipatags %}
-
-<h1>Laskennan tilanne {% now " j.n.Y G:i"%} </h1>
-  <table border="0" id="taulukko" cellpadding="2">
-    {% for rivi in taulukko %}
-        <tr valign="top">
-        {%for sarake in rivi %}
-                {% if forloop.first %}
-                        <td width="50" fgcolor="#FFFFFF" bgcolor="#000000" ><font color="#FFFFFF">{{ sarake.1 }}</font></td>
-                {%else%}
-
-                {% if sarake.0 == "a" %}
-                        <td width="100" class='aloittamatta'>{{sarake.1|alaviiva_pois}}</td>
-                {%else%}{% if sarake.0 == "o" %}
-                        <td width="100" class='osittain'>{{sarake.1}}</td>
-                {%else%}{% if sarake.0 == "s" %}
-                        <td width="62" class='syotetty'>{{sarake.1}}</td>
-                {%else%}{% if sarake.0 == "t" %}
-                        <td width="100" class='tarkistettu'> {{sarake.1|alaviiva_pois}}</td>
-                {%else%}{% if sarake.0 == "v" %}
-                        <td width="62" class='virhe'> {{sarake.1|alaviiva_pois}}</td>
-                {%else%}
-                        <td width="62" >{{sarake.1}}</td>
-                {% endif %}
-                {% endif %}
-                {% endif %}
-                {% endif %}
-                {% endif %}
-                {% endif %}
-        {%endfor%}
-        </tr>
-      {%endfor%}
-   </table>
-
-<br /><br />
-  <table width="150" border="0" cellpadding="1">
-    <tr>
-      <td width="150" class='aloittamatta'>&nbsp;&nbsp;&nbsp;aloittamatta</td>
-    </tr>
-    <tr>
-      <td class='osittain'>&nbsp;&nbsp;&nbsp;syötetty osittain</td>
-    </tr>
-    <tr>
-      <td class='syotetty'>&nbsp;&nbsp;&nbsp;syötetty</td>
-    </tr>
-    <tr>
-      <td class='tarkistettu'>&nbsp;&nbsp;&nbsp;tarkistettu</td>
-    </tr>
-     <tr>
-     <td class='virhe'>&nbsp;&nbsp;&nbsp;syöttövirhe</td>
-    </tr>
-  </table>
-  <p><br />
-
-  </p>
-
-</body>
-
+    <body>
+        {% load kipatags %}
+        <h1>Laskennan tilanne {% now " j.n.Y G:i" %}</h1>
+        <table border="0" id="taulukko" cellpadding="2">
+            {% for rivi in taulukko %}
+                <tr valign="top">
+                    {% for sarake in rivi %}
+                        {% if forloop.first %}
+                            <td width="50" fgcolor="#FFFFFF" bgcolor="#000000">
+                                <font color="#FFFFFF">{{ sarake.1 }}</font>
+                            </td>
+                        {% else %}
+                            {% if sarake.0 == "a" %}
+                                <td width="100" class='aloittamatta'>{{ sarake.1|alaviiva_pois }}</td>
+                            {% else %}
+                                {% if sarake.0 == "o" %}
+                                    <td width="100" class='osittain'>{{ sarake.1 }}</td>
+                                {% else %}
+                                    {% if sarake.0 == "s" %}
+                                        <td width="62" class='syotetty'>{{ sarake.1 }}</td>
+                                    {% else %}
+                                        {% if sarake.0 == "t" %}
+                                            <td width="100" class='tarkistettu'>{{ sarake.1|alaviiva_pois }}</td>
+                                        {% else %}
+                                            {% if sarake.0 == "v" %}
+                                                <td width="62" class='virhe'>{{ sarake.1|alaviiva_pois }}</td>
+                                            {% else %}
+                                                <td width="62">{{ sarake.1 }}</td>
+                                            {% endif %}
+                                        {% endif %}
+                                    {% endif %}
+                                {% endif %}
+                            {% endif %}
+                        {% endif %}
+                    {% endfor %}
+                </tr>
+            {% endfor %}
+        </table>
+        <br />
+        <br />
+        <table width="150" border="0" cellpadding="1">
+            <tr>
+                <td width="150" class='aloittamatta'>&nbsp;&nbsp;&nbsp;aloittamatta</td>
+            </tr>
+            <tr>
+                <td class='osittain'>&nbsp;&nbsp;&nbsp;syötetty osittain</td>
+            </tr>
+            <tr>
+                <td class='syotetty'>&nbsp;&nbsp;&nbsp;syötetty</td>
+            </tr>
+            <tr>
+                <td class='tarkistettu'>&nbsp;&nbsp;&nbsp;tarkistettu</td>
+            </tr>
+            <tr>
+                <td class='virhe'>&nbsp;&nbsp;&nbsp;syöttövirhe</td>
+            </tr>
+        </table>
+        <p>
+            <br />
+        </p>
+    </body>
 {% endblock %}
-

--- a/web/templates/tupa/login.html
+++ b/web/templates/tupa/login.html
@@ -1,15 +1,11 @@
 <!-- Käydään viestit läpi -->
-{% for message in messages %}
-{{ message }}
-{% endfor %}
-
+{% for message in messages %}{{ message }}{% endfor %}
 {% if user.is_authenticated %}
-<a href="/kipa/logout">Kirjaudu ulos</a>
+    <a href="/kipa/logout">Kirjaudu ulos</a>
 {% else %}
-<form action="/kipa/login/" name="form1" id="form1" method="post">
-    <input type="text" id="uname" name="uname">
-    <input type="password" id="pword" name="pword">
-    <button type="submit" class="small blue awesome" style="height:20px;">Kirjaudu »</button>
-</form>
+    <form action="/kipa/login/" name="form1" id="form1" method="post">
+        <input type="text" id="uname" name="uname">
+        <input type="password" id="pword" name="pword">
+        <button type="submit" class="small blue awesome" style="height:20px;">Kirjaudu »</button>
+    </form>
 {% endif %}
-

--- a/web/templates/tupa/maarita.html
+++ b/web/templates/tupa/maarita.html
@@ -1,36 +1,30 @@
 {% extends "tupa/base.html" %}
 {% block title %}{{ heading }}{% endblock %}
 {% block content %}
-
-{% load kipatags %}
-
-<h1>{{heading|alaviiva_pois}}</h1>
-
-<form method="POST" action="">
-<p>{% include "tupa/tallenna.html" %}</p>
-{% if forms %}
-    {% for form in forms%}
-        <fieldset>
-        <legend>{{form.label}}</legend>
-        {{form}}
-        {{form.helppiteksti}}<br>
-    </fieldset>
-    {% endfor%}
-{% endif %}
-<br>
-{% if formsets %}
-    {% for formset in formsets %}
-        <fieldset>
-        <legend>{{formset.label}} {{formset.helppiteksti}} </legend>
-        {{ formset.management_form }}
-        {% for form in formset.forms %}
-            <div class="oneRowInlineForm">
-                {{ form }}
-            </div>
-        {% endfor %}
-    </fieldset>
-    {% endfor%}
-{% endif %}
-{% include "tupa/tallenna.html" %}
-</form>
+    {% load kipatags %}
+    <h1>{{ heading|alaviiva_pois }}</h1>
+    <form method="POST" action="">
+        <p>{% include "tupa/tallenna.html" %}</p>
+        {% if forms %}
+            {% for form in forms %}
+                <fieldset>
+                    <legend>{{ form.label }}</legend>
+                    {{ form }}
+                    {{ form.helppiteksti }}
+                    <br>
+                </fieldset>
+            {% endfor %}
+        {% endif %}
+        <br>
+        {% if formsets %}
+            {% for formset in formsets %}
+                <fieldset>
+                    <legend>{{ formset.label }} {{ formset.helppiteksti }}</legend>
+                    {{ formset.management_form }}
+                    {% for form in formset.forms %}<div class="oneRowInlineForm">{{ form }}</div>{% endfor %}
+                </fieldset>
+            {% endfor %}
+        {% endif %}
+        {% include "tupa/tallenna.html" %}
+    </form>
 {% endblock %}

--- a/web/templates/tupa/maaritaValitseTehtava.html
+++ b/web/templates/tupa/maaritaValitseTehtava.html
@@ -1,11 +1,13 @@
 {% extends "tupa/valitse.html" %}
 {{ block.super }}
-
 {% block sarake %}
-        <form method="POST" action="">
+    <form method="POST" action="">
         {{ sarake }}
-        <h3><a href="uusi/sarja/{{ sarake.id }}/">Lisää uusi tehtävä</a> </h3>
-        <h3><a href="kopioi/sarjaan/{{ sarake.id }}/">Kopioi tehtäviä tähän sarjaan</a> </h3>
+        <h3>
+            <a href="uusi/sarja/{{ sarake.id }}/">Lisää uusi tehtävä</a>
+        </h3>
+        <h3>
+            <a href="kopioi/sarjaan/{{ sarake.id }}/">Kopioi tehtäviä tähän sarjaan</a>
+        </h3>
         {% include "tupa/poista.html" %}
-{% endblock%}
-
+    {% endblock %}

--- a/web/templates/tupa/maarita_riisuttu.html
+++ b/web/templates/tupa/maarita_riisuttu.html
@@ -1,33 +1,28 @@
 {% extends "tupa/base_riisuttu.html" %}
 {% block title %}{{ heading }}{% endblock %}
 {% block content %}
-
-<h1>{{ heading }}</h1>
-
-<form method="POST" action="">
-<p>{% include "tupa/tallenna.html" %}</p>
-{% if forms %}
-    {% for form in forms%}
-        <fieldset>
-        <legend>{{form.label}} </legend>
-        {{form}} <br>
-    </fieldset>
-    {% endfor%}
-{% endif %}
-<br>
-{% if formsets %}
-    {% for formset in formsets %}
-        <fieldset>
-        <legend>{{formset.label}}</legend>
-        {{ formset.management_form }}
-        {% for form in formset.forms %}
-            <div class="oneRowInlineForm">
-                {{ form }}
-            </div>
-        {% endfor %}
-    </fieldset>
-    {% endfor%}
-{% endif %}
-{% include "tupa/tallenna.html" %}
-</form>
+    <h1>{{ heading }}</h1>
+    <form method="POST" action="">
+        <p>{% include "tupa/tallenna.html" %}</p>
+        {% if forms %}
+            {% for form in forms %}
+                <fieldset>
+                    <legend>{{ form.label }}</legend>
+                    {{ form }}
+                    <br>
+                </fieldset>
+            {% endfor %}
+        {% endif %}
+        <br>
+        {% if formsets %}
+            {% for formset in formsets %}
+                <fieldset>
+                    <legend>{{ formset.label }}</legend>
+                    {{ formset.management_form }}
+                    {% for form in formset.forms %}<div class="oneRowInlineForm">{{ form }}</div>{% endfor %}
+                </fieldset>
+            {% endfor %}
+        {% endif %}
+        {% include "tupa/tallenna.html" %}
+    </form>
 {% endblock %}

--- a/web/templates/tupa/poista.html
+++ b/web/templates/tupa/poista.html
@@ -1,6 +1,8 @@
 <br>
 <table>
-<tr>
-<td width="100" align="right"><button type="submit" class="small red awesome" title="Poista valitut">Poista valitut</button></td>
-</tr>
+    <tr>
+        <td width="100" align="right">
+            <button type="submit" class="small red awesome" title="Poista valitut">Poista valitut</button>
+        </td>
+    </tr>
 </table>

--- a/web/templates/tupa/poista_kisa.html
+++ b/web/templates/tupa/poista_kisa.html
@@ -1,29 +1,31 @@
 {% extends "tupa/base.html" %}
 {% block title %}{{ heading }}{% endblock %}
 {% block content %}
-<h1> {{heading}} </h1>
-
-<form method="POST" action="">
-<br>
-<br>
-<br>
-<font size=5 >
-Olet poistamassa kisaa {{kisa_nimi}} <br>
-<br>
-Oletko tosissasi?
-<br>
-<br>
-</font>
-
-
-<table>
-<tr>
-<td width="200" align="right"><button type="button" class="small awesome" onClick="history.back();" title="Palaa edelliselle sivulle">Peruuta</button></td>
-<td width="100" align="right"><button type="submit" class="small blue awesome" >Kyllä</button></td>
-</tr>
-</table>
-
-</form>
-
+    <h1>{{ heading }}</h1>
+    <form method="POST" action="">
+        <br>
+        <br>
+        <br>
+        <font size=5>
+            Olet poistamassa kisaa {{ kisa_nimi }}
+            <br>
+            <br>
+            Oletko tosissasi?
+            <br>
+            <br>
+        </font>
+        <table>
+            <tr>
+                <td width="200" align="right">
+                    <button type="button"
+                            class="small awesome"
+                            onClick="history.back();"
+                            title="Palaa edelliselle sivulle">Peruuta</button>
+                </td>
+                <td width="100" align="right">
+                    <button type="submit" class="small blue awesome">Kyllä</button>
+                </td>
+            </tr>
+        </table>
+    </form>
 {% endblock %}
-

--- a/web/templates/tupa/syota_tehtava.html
+++ b/web/templates/tupa/syota_tehtava.html
@@ -1,19 +1,25 @@
 {% extends "tupa/base.html" %}
-
 {% load kipatags %}
-
-{% block title %}{{tehtava.nimi}}{% endblock %}
+{% block title %}{{ tehtava.nimi }}{% endblock %}
 {% block header %}
-{{ block.super }}
-<script type="text/javascript" language="javascript" src="/kipamedia/jquery.maskedinput-1.3.js"></script>
-<script type="text/javascript" language="javascript" src="/kipamedia/jquery.stickytableheaders.js"></script>
-<script type="text/javascript" language="javascript" src="/kipamedia/keyhandler.js"></script>
-<script type="text/javascript" language="javascript" src="/kipamedia/tooltip.js"></script>
-<style type="text/css">
+    {{ block.super }}
+    <script type="text/javascript"
+            language="javascript"
+            src="/kipamedia/jquery.maskedinput-1.3.js"></script>
+    <script type="text/javascript"
+            language="javascript"
+            src="/kipamedia/jquery.stickytableheaders.js"></script>
+    <script type="text/javascript"
+            language="javascript"
+            src="/kipamedia/keyhandler.js"></script>
+    <script type="text/javascript"
+            language="javascript"
+            src="/kipamedia/tooltip.js"></script>
+    <style type="text/css">
     label { width: 10em; float: left; }
     label.error { float: none; color: red; padding-left: .5em; vertical-align: top; }
-</style>
-<script type="text/javascript">
+    </style>
+    <script type="text/javascript">
 $(document).ready(function(){
     $("#taulukko").stickyTableHeaders();
 
@@ -29,144 +35,141 @@ $(document).ready(function(){
     });
     });
 
-</script>
-{% endblock header%}
-
+    </script>
+{% endblock header %}
 {% block content %}
-
-<h1>{{tehtava.nimi|alaviiva_pois}}</h1>
-
-<form action="." name="form1" id="form1" method="post">
-
-<p>{% include "tupa/tallenna.html" %}</p>
-
-<table width="600" border="0" cellpadding="2" cellspacing="0">
-  <tr>
-    <td width="100" class="tauluOtsikko">Tehtävä:</td>
-    <td colspan="2" bgcolor="#E8EDFF">{{tehtava.jarjestysnro}} &nbsp; &nbsp; {{tehtava.nimi|alaviiva_pois}}</td>
-  </tr>
-  <tr>
-    <td class="tauluOtsikko">Sarja: </td>
-    <td colspan="2" bgcolor="#E8EDFF">{{tehtava.sarja.nimi}}</td>
-  </tr>
-  <tr valign="middle">
-    <td valign="middle" class="tauluOtsikko">Tehtävän tila:</td>
-    {%if tilanne.0 == "a"%}
-    <td width="150" valign="middle" class='aloittamatta'><label>aloittamatta</label></td>
-    {% endif %}
-    {%if tilanne.0 == "o"%}
-    <td width="150" valign="middle" class='osittain'><label>syötetty osittain</label></td>
-    {% endif %}
-    {%if tilanne.0 == "s"%}
-    <td width="150" valign="middle" class='syotetty'><label>syötetty</label></td>
-    {% endif %}
-    {%if tilanne.0 == "t"%}
-    <td width="150" valign="middle" class='tarkistettu'><label>tarkistettu</label></td>
-    {% endif %}
-    {%if tilanne.0 == "v"%}
-    <td width="150" valign="middle" class='virhe'><label>syöttövirhe</label></td>
-    {% endif %}
-
-
-    <td bgcolor="#E8EDFF"><label><input type="checkbox" {%if tarkistettu %}checked="checked" {% endif %} name="tarkistettu" id="tarkistettu" />tarkistettu</label></td>
-  </tr>
-{% if tarkistus %}<tr bgcolor="#ff9900"><td colspan=3>Syötät tarkistustuloksia</td></tr>{% endif %}
-</table>
-<br />
-
-
-    <table id="taulukko" border="0" cellpadding="2" cellspacing="0">
-    <thead>
-        <tr>
-            <th colspan="2">
-            Osatehtävä:
-            </th>
-            {% for osatehtava in osatehtavat %}
-               <th class="osatehtava_otsikko" colspan="{{osatehtava.syotemaarite_set.all|length}}">
-                   Osatehtävä {{ osatehtava.nimi }}
-               </th>
-               <th class="th_erotin" width=1></th>
-            {% endfor %}
-        </tr>
-        <tr>
-            <th colspan="2">
-            Syötteen nimi:
-            </th>
-            {% for osatehtava in osatehtavat %}
-                {% for maarite in osatehtava.syotemaarite_set.all %}
-                   <th>
-                       {{ maarite.nimi }}
-                   </th>
-                {% endfor %}
-                <th class="th_erotin"></th>
-            {% endfor %}
-        </tr>
-        <tr>
-            <th colspan="2">
-            Syötteen tyyppi:
-            </th>
-            {% for osatehtava in osatehtavat %}
-                {% for maarite in osatehtava.syotemaarite_set.all %}
-                   <th>
-                       {{ maarite.tyyppi }}
-                       {% if maarite.tyyppi == "aika" %}(hh:mm:ss){% endif %}
-                   </th>
-                {% endfor %}
-                <th class="th_erotin"></th>
-            {% endfor %}
-        </tr>
-        <tr>
-            <th colspan="2">
-            Syötteen kuvaus:
-            </th>
-            {% for osatehtava in osatehtavat %}
-                {% for maarite in osatehtava.syotemaarite_set.all %}
-                   <th>
-                       {{ maarite.kali_vihje }}
-                   </th>
-                {% endfor %}
-                <th class="th_erotin"></th>
-            {% endfor %}
-        </tr>
-    </thead>
-
-    <tbody>
-        {% for vartio in syotteet %}
-            <tr valign="top" class="{% if forloop.counter|divisibleby:2 %}even{% else %}odd{% endif %}">
-                  <td width="15">
-                  {{ vartio.0.nro}}
-                  </td>
-                <td width="200">
-                        {{ vartio.0.nimi }}
-                </td>
-                    {% for osatehtava in vartio.1 %}
-                        {% for kentta in osatehtava %}
-                            <td{% if  kentta.syottovirhe %}
-                                bgcolor="#FF4F00"
-                            {%endif%}>
-
-                             {{kentta.errors}}
-                             {{kentta.arvo}}
-                             {{kentta.tarkistus}}
-                             </td>
-                        {% endfor %}
-                    <td class="th_erotin"></td>
-                {% endfor %}
+    <h1>{{ tehtava.nimi|alaviiva_pois }}</h1>
+    <form action="." name="form1" id="form1" method="post">
+        <p>{% include "tupa/tallenna.html" %}</p>
+        <table width="600" border="0" cellpadding="2" cellspacing="0">
+            <tr>
+                <td width="100" class="tauluOtsikko">Tehtävä:</td>
+                <td colspan="2" bgcolor="#E8EDFF">{{ tehtava.jarjestysnro }} &nbsp; &nbsp; {{ tehtava.nimi|alaviiva_pois }}</td>
             </tr>
-        {% endfor %}
-    </tbody>
-    </table>
-    {% include "tupa/tallenna.html" %}
+            <tr>
+                <td class="tauluOtsikko">Sarja:</td>
+                <td colspan="2" bgcolor="#E8EDFF">{{ tehtava.sarja.nimi }}</td>
+            </tr>
+            <tr valign="middle">
+                <td valign="middle" class="tauluOtsikko">Tehtävän tila:</td>
+                {% if tilanne.0 == "a" %}
+                    <td width="150" valign="middle" class='aloittamatta'>
+                        <label>aloittamatta</label>
+                    </td>
+                {% endif %}
+                {% if tilanne.0 == "o" %}
+                    <td width="150" valign="middle" class='osittain'>
+                        <label>syötetty osittain</label>
+                    </td>
+                {% endif %}
+                {% if tilanne.0 == "s" %}
+                    <td width="150" valign="middle" class='syotetty'>
+                        <label>syötetty</label>
+                    </td>
+                {% endif %}
+                {% if tilanne.0 == "t" %}
+                    <td width="150" valign="middle" class='tarkistettu'>
+                        <label>tarkistettu</label>
+                    </td>
+                {% endif %}
+                {% if tilanne.0 == "v" %}
+                    <td width="150" valign="middle" class='virhe'>
+                        <label>syöttövirhe</label>
+                    </td>
+                {% endif %}
+                <td bgcolor="#E8EDFF">
+                    <label>
+                        <input type="checkbox"
+                               {% if tarkistettu %}checked="checked"{% endif %}
+                               name="tarkistettu"
+                               id="tarkistettu" />
+                        tarkistettu
+                    </label>
+                </td>
+            </tr>
+            {% if tarkistus %}
+                <tr bgcolor="#ff9900">
+                    <td colspan=3>Syötät tarkistustuloksia</td>
+                </tr>
+            {% endif %}
+        </table>
+        <br />
+        <table id="taulukko" border="0" cellpadding="2" cellspacing="0">
+            <thead>
+                <tr>
+                    <th colspan="2">Osatehtävä:</th>
+                    {% for osatehtava in osatehtavat %}
+                        <th class="osatehtava_otsikko"
+                            colspan="{{ osatehtava.syotemaarite_set.all|length }}">
+                            Osatehtävä {{ osatehtava.nimi }}
+                        </th>
+                        <th class="th_erotin" width=1></th>
+                    {% endfor %}
+                </tr>
+                <tr>
+                    <th colspan="2">Syötteen nimi:</th>
+                    {% for osatehtava in osatehtavat %}
+                        {% for maarite in osatehtava.syotemaarite_set.all %}<th>{{ maarite.nimi }}</th>{% endfor %}
+                        <th class="th_erotin"></th>
+                    {% endfor %}
+                </tr>
+                <tr>
+                    <th colspan="2">Syötteen tyyppi:</th>
+                    {% for osatehtava in osatehtavat %}
+                        {% for maarite in osatehtava.syotemaarite_set.all %}
+                            <th>
+                                {{ maarite.tyyppi }}
+                                {% if maarite.tyyppi == "aika" %}(hh:mm:ss){% endif %}
+                            </th>
+                        {% endfor %}
+                        <th class="th_erotin"></th>
+                    {% endfor %}
+                </tr>
+                <tr>
+                    <th colspan="2">Syötteen kuvaus:</th>
+                    {% for osatehtava in osatehtavat %}
+                        {% for maarite in osatehtava.syotemaarite_set.all %}<th>{{ maarite.kali_vihje }}</th>{% endfor %}
+                        <th class="th_erotin"></th>
+                    {% endfor %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for vartio in syotteet %}
+                    <tr valign="top"
+                        class="{% if forloop.counter|divisibleby:2 %}even{% else %}odd{% endif %}">
+                        <td width="15">{{ vartio.0.nro }}</td>
+                        <td width="200">{{ vartio.0.nimi }}</td>
+                        {% for osatehtava in vartio.1 %}
+                            {% for kentta in osatehtava %}
+                                <td {% if  kentta.syottovirhe %}bgcolor="#FF4F00"{% endif %}>
+                                    {{ kentta.errors }}
+                                    {{ kentta.arvo }}
+                                    {{ kentta.tarkistus }}
+                                </td>
+                            {% endfor %}
+                            <td class="th_erotin"></td>
+                        {% endfor %}
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% include "tupa/tallenna.html" %}
     </form>
-
-<p>
-e - vartio ei ole tehnyt tehtävää<br />
-h - vartion suoritus on hylätty<br />
-</p>
-
-{% if tarkistus %}<p>Syötät tällä hetkellä tarkistussyötteitä. <a href="{{varsinaiset_syotteet_url}}">Katso tehtävän varsinaiset syötteet</a></p>{% endif %}
-<p><a href="{{maaritys_url}}">Tehtävän määrittely</a></p>
-<p><a href="{{tulokset_url}}">Tämän sarjan tulokset</a></p>
-
+    <p>
+        e - vartio ei ole tehnyt tehtävää
+        <br />
+        h - vartion suoritus on hylätty
+        <br />
+    </p>
+    {% if tarkistus %}
+        <p>
+            Syötät tällä hetkellä tarkistussyötteitä. <a href="{{ varsinaiset_syotteet_url }}">Katso tehtävän varsinaiset syötteet</a>
+        </p>
+    {% endif %}
+    <p>
+        <a href="{{ maaritys_url }}">Tehtävän määrittely</a>
+    </p>
+    <p>
+        <a href="{{ tulokset_url }}">Tämän sarjan tulokset</a>
+    </p>
 {% endblock %}
-

--- a/web/templates/tupa/syota_tehtava.html
+++ b/web/templates/tupa/syota_tehtava.html
@@ -5,7 +5,6 @@
 {% block title %}{{tehtava.nimi}}{% endblock %}
 {% block header %}
 {{ block.super }}
-<!--<script type="text/javascript" language="javascript" src="/kipamedia/jquery.form-changed-warning.js"></script>-->
 <script type="text/javascript" language="javascript" src="/kipamedia/jquery.maskedinput-1.3.js"></script>
 <script type="text/javascript" language="javascript" src="/kipamedia/jquery.stickytableheaders.js"></script>
 <script type="text/javascript" language="javascript" src="/kipamedia/keyhandler.js"></script>
@@ -28,19 +27,6 @@ $(document).ready(function(){
        $.mask.definitions['~']='[he0123456789]'; /* hylätty, ei syötetty, numeroarvot*/
        $(".time").mask("~?9:99:99");
     });
-
-/*    jQuery("input#kopioi_sarake1").click(function(){
-        if ($("input#kopioi_sarake1").is(':checked'))
-        {
-            // Checked, copy values
-            $("input.col0").val($("input#copy_from1").val());
-        }
-        else
-        {
-            // Clear on uncheck
-            $("input.col0").val("");
-        }
-*/
     });
 
 </script>
@@ -63,11 +49,6 @@ $(document).ready(function(){
     <td class="tauluOtsikko">Sarja: </td>
     <td colspan="2" bgcolor="#E8EDFF">{{tehtava.sarja.nimi}}</td>
   </tr>
-<!--  <tr>
-    <td valign="middle" class="tauluOtsikko">Yhteyshenkilö:</td>
-    <td valign="middle" bgcolor="#E8EDFF">&nbsp;</td>
-    <td bgcolor="#E8EDFF">&nbsp;</td>
-  </tr>-->
   <tr valign="middle">
     <td valign="middle" class="tauluOtsikko">Tehtävän tila:</td>
     {%if tilanne.0 == "a"%}
@@ -147,19 +128,6 @@ $(document).ready(function(){
                 <th class="th_erotin"></th>
             {% endfor %}
         </tr>
-<!--        <tr>
-            <th colspan="2">Käytä oletusarvoa:</th>
-            {% for osatehtava in osatehtavat %}
-                {% for maarite in osatehtava.syotemaarite_set.all %}
-                   <th>
-                       <input type="checkbox" id="kopioi_sarake{{forloop.counter}}" />
-                       <input type="text" id="copy_from{{forloop.counter}}" size="8" />
-                   </th>
-                {% endfor %}
-                <th class="th_erotin"></th>
-            {% endfor %}
-        </tr>
--->
     </thead>
 
     <tbody>

--- a/web/templates/tupa/tallenna.html
+++ b/web/templates/tupa/tallenna.html
@@ -1,7 +1,18 @@
 <br>
-<button type="button" class="small awesome" onClick="history.back();" title="Palaa edelliselle sivulle tallentamatta muutoksia">Peruuta</button>&nbsp;&nbsp;&nbsp;
-<button name="tallenna" type="submit" class="small blue awesome" title="Tallenna sivulla näkyvät tiedot">Tallenna »</button>
-{% if ohjaus_nappi %}
+<button type="button"
+        class="small awesome"
+        onClick="history.back();"
+        title="Palaa edelliselle sivulle tallentamatta muutoksia">Peruuta</button>
 &nbsp;&nbsp;&nbsp;
-<button name="nappi" type="submit" value="ohjaus" class="small blue awesome" title="Tallenna sivulla näkyvät tiedot">Tallenna ja {{ohjaus_nappi}}</button>
+<button name="tallenna"
+        type="submit"
+        class="small blue awesome"
+        title="Tallenna sivulla näkyvät tiedot">Tallenna »</button>
+{% if ohjaus_nappi %}
+    &nbsp;&nbsp;&nbsp;
+    <button name="nappi"
+            type="submit"
+            value="ohjaus"
+            class="small blue awesome"
+            title="Tallenna sivulla näkyvät tiedot">Tallenna ja {{ ohjaus_nappi }}</button>
 {% endif %}

--- a/web/templates/tupa/testitulos.html
+++ b/web/templates/tupa/testitulos.html
@@ -1,31 +1,24 @@
 {% extends "tupa/valitse.html" %}
-
 {% block sarake %}
     <table width="600" border="1">
         <tr>
-        <td></td>
-                {% for kentta in sarake.tiedot.0.tehtavat %}
-                        <td>
-                                {{ kentta.nimi }}
-                        </td>
-                {% endfor %}
+            <td></td>
+            {% for kentta in sarake.tiedot.0.tehtavat %}<td>{{ kentta.nimi }}</td>{% endfor %}
         </tr>
-        <a href="/kipa/{{sarake.sarja.kisa.nimi}}/luo/sarja/{{sarake.sarja.id}}/testitulokset/">
-        luo testitulokset sarjalle </a><br>
+        <a href="/kipa/{{ sarake.sarja.kisa.nimi }}/luo/sarja/{{ sarake.sarja.id }}/testitulokset/">
+        luo testitulokset sarjalle </a>
+        <br>
         {% for rivi in sarake.tiedot %}
-                <tr>
-                <td>{{rivi.nimi}}</td>
-                {% for kentta in rivi.formit%}
-                    <td>{{ kentta }}{{kentta.errors}}</td>
-                {% endfor %}
+            <tr>
+                <td>{{ rivi.nimi }}</td>
+                {% for kentta in rivi.formit %}<td>{{ kentta }}{{ kentta.errors }}</td>{% endfor %}
             </tr>
         {% endfor %}
     </table>
-{% endblock%}
+{% endblock %}
 {% block content %}
-        <form action="." method="post">
+    <form action="." method="post">
         {{ block.super }}
         {% include "tupa/tallenna.html" %}
-{% endblock%}
+    {% endblock %}
 </form>
-

--- a/web/templates/tupa/tulokset.html
+++ b/web/templates/tupa/tulokset.html
@@ -1,184 +1,223 @@
 {% extends "tupa/base.html" %}
-{% block title %}Sarjakohtaiset tulokset{% endblock title %}
+{% block title %}
+    Sarjakohtaiset tulokset
+{% endblock title %}
 {% block header %}
-{% if vaihtoaika %}
-<meta http-equiv="REFRESH" content="{{vaihtoaika}};url=/kipa/{{kisa_nimi}}/heijasta/sarja/{{vaihto_id}}/">
-{% endif %}
+    {% if vaihtoaika %}
+        <meta http-equiv="REFRESH"
+              content="{{ vaihtoaika }};url=/kipa/{{ kisa_nimi }}/heijasta/sarja/{{ vaihto_id }}/">
+    {% endif %}
 {% endblock header %}
 {% block content %}
-
-{% load kipatags %}
-
-<table width="100%" border="0" id="tulostaulukko_otsikko">
-<tr valign="top">
-    <td width="33%"><h1 style="margin:0; padding:0;">{{kisa_nimi|alaviiva_pois }}</h1></td>
-    <td width="33%" align="center"><h1>{{heading}}</h1></td>
-    <td width="33%" align="right">&nbsp;</td>
-</tr>
-<tr>
-    <td>{%if kisa_aika %}
-            {{kisa_aika}}<br>
-        {% endif %}
-        {{kisa_paikka}}
-    </td>
-    <td align="center"><br>{% now "j.n.Y G:i"%}</td>
-    <td align="right">&nbsp;</td>
-</tr>
-</table>
-<br />
-
-{% if tulos_taulukko %}
-    <table id="tulostaulukko_screen" border=0 >
-        {% for rivi in tulos_taulukko%}
-                {%if forloop.counter|add:"3"|divisibleby:"5" %}
-                        <tr height="10" valign="top"><td></td></tr>
+    {% load kipatags %}
+    <table width="100%" border="0" id="tulostaulukko_otsikko">
+        <tr valign="top">
+            <td width="33%">
+                <h1 style="margin:0; padding:0;">{{ kisa_nimi|alaviiva_pois }}</h1>
+            </td>
+            <td width="33%" align="center">
+                <h1>{{ heading }}</h1>
+            </td>
+            <td width="33%" align="right">&nbsp;</td>
+        </tr>
+        <tr>
+            <td>
+                {% if kisa_aika %}
+                    {{ kisa_aika }}
+                    <br>
+                {% endif %}
+                {{ kisa_paikka }}
+            </td>
+            <td align="center">
+                <br>
+                {% now "j.n.Y G:i" %}
+            </td>
+            <td align="right">&nbsp;</td>
+        </tr>
+    </table>
+    <br />
+    {% if tulos_taulukko %}
+        <table id="tulostaulukko_screen" border=0>
+            {% for rivi in tulos_taulukko %}
+                {% if forloop.counter|add:"3"|divisibleby:"5" %}
+                    <tr height="10" valign="top">
+                        <td></td>
+                    </tr>
                 {% endif %}
                 {% if forloop.first %}
-                      <tr valign="top">
-                {% for sarake in rivi %}
-                     {% comment %} ylarivi {% endcomment %}
-                                {% if forloop.first  %}
-                                        {% comment %} ylarivin eka {% endcomment %}
-                                        <td width="30" align="right"></td>
-                                        <td width="30" align="right" style="padding-right:10px;"><b></b></td>
-                                        <td style="min-width:100px;"></td>
-                                        <td align="right" width=30 style="padding-right:10px;"></td>
-                                {% else %}
-                                        {% comment %} ylarivi {% endcomment %}
-
-                                        {% if sarake.jarjestysnro %}
-                                        <td align="right" width=30 style="padding-right:10px;">
-                                            <b>{{ sarake.jarjestysnro }}.</b>
-                                        </td>
-                                        {% endif %}
+                    <tr valign="top">
+                        {% for sarake in rivi %}
+                            {% comment %} ylarivi {% endcomment %}
+                            {% if forloop.first %}
+                                {% comment %} ylarivin eka {% endcomment %}
+                                <td width="30" align="right"></td>
+                                <td width="30" align="right" style="padding-right:10px;">
+                                    <b></b>
+                                </td>
+                                <td style="min-width:100px;"></td>
+                                <td align="right" width=30 style="padding-right:10px;"></td>
+                            {% else %}
+                                {% comment %} ylarivi {% endcomment %}
+                                {% if sarake.jarjestysnro %}
+                                    <td align="right" width=30 style="padding-right:10px;">
+                                        <b>{{ sarake.jarjestysnro }}.</b>
+                                    </td>
                                 {% endif %}
-                {% endfor %}
-
-                      </tr>
-                      <tr valign="top">
-
+                            {% endif %}
+                        {% endfor %}
+                    </tr>
+                    <tr valign="top">
                         <td></td>
                         {% for sarake in rivi %}
-                     {% comment %} ylarivi {% endcomment %}
-                                {% if forloop.first  %}
-                                        {% comment %} ylarivin eka {% endcomment %}
-                                        <td></td><td></td>
+                            {% comment %} ylarivi {% endcomment %}
+                            {% if forloop.first %}
+                                {% comment %} ylarivin eka {% endcomment %}
+                                <td></td>
+                                <td></td>
+                            {% else %}
+                                {% comment %} ylarivi {% endcomment %}
+                                {% if sarake.lyhenne %}
+                                    <td align="right" style="padding-right:10px;">
+                                        <b>{{ sarake.lyhenne }}</b>
+                                    </td>
                                 {% else %}
-                                        {% comment %} ylarivi {% endcomment %}
-                                        {%if sarake.lyhenne %}
-                                        <td align="right" style="padding-right:10px;"><b>{{sarake.lyhenne}}</b></td>
-                                        {% else %}
-                                        <td align="right" width="60" style="padding-right:10px;"><b>
-                                            {{sarake.nimi|slice:":6"}}<br />
-                                            {{sarake.nimi|slice:"6:13"}}<br />
-                                            {{sarake.nimi|slice:"13:19"}}<br />
-                                            {{sarake.nimi|slice:"19:25"}}</b>
-                                        </td>
-                                        {% endif %}
+                                    <td align="right" width="60" style="padding-right:10px;">
+                                        <b>
+                                            {{ sarake.nimi|slice:":6" }}
+                                            <br />
+                                            {{ sarake.nimi|slice:"6:13" }}
+                                            <br />
+                                            {{ sarake.nimi|slice:"13:19" }}
+                                            <br />
+                                        {{ sarake.nimi|slice:"19:25" }}</b>
+                                    </td>
                                 {% endif %}
-                        {%endfor %}
-
-                      </tr>
-                      <tr valign="top">
-                      <td></td><td></td><td align="right"><em>Maxpisteet</em></td>
-                        {% for sarake in rivi %}
-                                {% if forloop.first  %}
-                               <td align="right" style="padding-right:10px;"><em> {{ sarake.maksimipisteet }} </em></td>
-                                {% else %}
-
-                                {% if forloop.counter != 0 %}
-                                {% if forloop.counter != 1 %}
-                                {% if forloop.counter != 2 %}
-                                        <td align="right" style="padding-right:10px;"><em> {{ sarake.maksimipisteet }} </em></td>
-                                {% endif %}
-                                {% endif %}
-                                {% endif %}
-                                {% endif %}
-
-                        {%endfor %}
-                      </tr>
-                      <tr>
-                            <td width="30" align="right"><b>SIJ.</b></td>
-                            <td width="30" align="right" style="padding-right:10px;"><b></b></td>
-                            <td style="min-width:100px;"><b>VARTIO</b></td>
-                            <td align="right" width=30 style="padding-right:10px;"><b>YHT</b></td>
-                      </tr>
-
-                      <tr valign='top'>
-
-                {% else %}
-                {% for sarake in rivi %}
-                     {% comment %} ylarivi {% endcomment %}
-                     {% if forloop.counter == 2 %}
-                     {% comment %} ekasarake {% endcomment %}
-                        <td align="right" style="padding-right:10px;"> {{ sarake.nro }}</td> <td>{{sarake.nimi}}
-                                                {%if sarake.lippukunta %}<br>{%endif%}
-                                                {{sarake.lippukunta}}
-                                                {%if sarake.piiri %}<br>{%endif%}
-                                                {{sarake.piiri}}</td>
-                     {% else %}
-                     {% if forloop.counter == 3 %}
-                        <td align="right" style="padding-right:10px;">{{sarake}}</td>
-                     {% comment %} muut sarakkeet {% endcomment %}
-                     {% else %}
-                        <td align="right" style="padding-right:10px;">
-                                {% if forloop.first %} <b> {%endif%}
-                                        {{ sarake }}
-                                {% if forloop.first %} </b> {%endif%}
+                            {% endif %}
+                        {% endfor %}
+                    </tr>
+                    <tr valign="top">
+                        <td></td>
+                        <td></td>
+                        <td align="right">
+                            <em>Maxpisteet</em>
                         </td>
-                     {% endif %}
-                     {% endif %}
-
-                {% endfor %}
-                     {% endif %}
-              </tr>
-               {% comment %} ULKONA OLEVAT: {% endcomment %}
-                {% if forloop.last %}
-                        <tr><td>&nbsp;  </td></tr>
-                        <tr><td> </td> <td></td><td><b>Ulkopuolella:</b> </td></tr>
-                        {% for rivi in ulkona_taulukko%}
-                        <tr valign='top'>
                         {% for sarake in rivi %}
-
-
-                                {% if forloop.counter == 2 %}
-                                        {% comment %} ekasarake {% endcomment %}
-                                        <td align="right" style="padding-right:10px;">{{ sarake.nro }}</td> <td>{{ sarake.nimi }}
-                                                {%if sarake.lippukunta %}<br>{%endif%}
-                                                {{sarake.lippukunta}}
-                                                {%if sarake.piiri %}<br> {%endif%}
-                                                {{sarake.piiri}} </td>
-
-                                {% else %}
-                                        {% comment %} muut sarakkeet {% endcomment %}
+                            {% if forloop.first %}
                                 <td align="right" style="padding-right:10px;">
-                                        {% if forloop.first %} <b> {%endif%}
-                                        {{ sarake }}
-                                        {% if forloop.first %} </b> {%endif%}
+                                    <em>{{ sarake.maksimipisteet }}</em>
                                 </td>
+                            {% else %}
+                                {% if forloop.counter != 0 %}
+                                    {% if forloop.counter != 1 %}
+                                        {% if forloop.counter != 2 %}
+                                            <td align="right" style="padding-right:10px;">
+                                                <em>{{ sarake.maksimipisteet }}</em>
+                                            </td>
+                                        {% endif %}
+                                    {% endif %}
                                 {% endif %}
+                            {% endif %}
                         {% endfor %}
+                    </tr>
+                    <tr>
+                        <td width="30" align="right">
+                            <b>SIJ.</b>
+                        </td>
+                        <td width="30" align="right" style="padding-right:10px;">
+                            <b></b>
+                        </td>
+                        <td style="min-width:100px;">
+                            <b>VARTIO</b>
+                        </td>
+                        <td align="right" width=30 style="padding-right:10px;">
+                            <b>YHT</b>
+                        </td>
+                    </tr>
+                    <tr valign='top'>
+                    {% else %}
+                        {% for sarake in rivi %}
+                            {% comment %} ylarivi {% endcomment %}
+                            {% if forloop.counter == 2 %}
+                                {% comment %} ekasarake {% endcomment %}
+                                <td align="right" style="padding-right:10px;">{{ sarake.nro }}</td>
+                                <td>
+                                    {{ sarake.nimi }}
+                                    {% if sarake.lippukunta %}<br>{% endif %}
+                                    {{ sarake.lippukunta }}
+                                    {% if sarake.piiri %}<br>{% endif %}
+                                    {{ sarake.piiri }}
+                                </td>
+                            {% else %}
+                                {% if forloop.counter == 3 %}
+                                    <td align="right" style="padding-right:10px;">{{ sarake }}</td>
+                                    {% comment %} muut sarakkeet {% endcomment %}
+                                {% else %}
+                                    <td align="right" style="padding-right:10px;">
+                                        {% if forloop.first %}<b>{% endif %}
+                                            {{ sarake }}
+                                            {% if forloop.first %}</b>{% endif %}
+                                    </td>
+                                {% endif %}
+                            {% endif %}
+                        {% endfor %}
+                    {% endif %}
+                </tr>
+                {% comment %} ULKONA OLEVAT: {% endcomment %}
+                {% if forloop.last %}
+                    <tr>
+                        <td>&nbsp;</td>
+                    </tr>
+                    <tr>
+                        <td></td>
+                        <td></td>
+                        <td>
+                            <b>Ulkopuolella:</b>
+                        </td>
+                    </tr>
+                    {% for rivi in ulkona_taulukko %}
+                        <tr valign='top'>
+                            {% for sarake in rivi %}
+                                {% if forloop.counter == 2 %}
+                                    {% comment %} ekasarake {% endcomment %}
+                                    <td align="right" style="padding-right:10px;">{{ sarake.nro }}</td>
+                                    <td>
+                                        {{ sarake.nimi }}
+                                        {% if sarake.lippukunta %}<br>{% endif %}
+                                        {{ sarake.lippukunta }}
+                                        {% if sarake.piiri %}<br>{% endif %}
+                                        {{ sarake.piiri }}
+                                    </td>
+                                {% else %}
+                                    {% comment %} muut sarakkeet {% endcomment %}
+                                    <td align="right" style="padding-right:10px;">
+                                        {% if forloop.first %}<b>{% endif %}
+                                            {{ sarake }}
+                                            {% if forloop.first %}</b>{% endif %}
+                                    </td>
+                                {% endif %}
+                            {% endfor %}
                         </tr>
-                        {%if forloop.counter|divisibleby:"5" %}
-                                        <tr height=10><td></td></tr>
+                        {% if forloop.counter|divisibleby:"5" %}
+                            <tr height=10>
+                                <td></td>
+                            </tr>
                         {% endif %}
-                        {% endfor %}
+                    {% endfor %}
                 {% endif %}
-        {% endfor %}
-
-    </table>
-
-{% else %}
-    <p>Ei tuloksia.</p>
-{% endif %}
-
-<p>
- S = syöttämättä<br>
- H = vartion suoritus hylätty<br>
- K = vartio keskeyttänyt<br>
- E = vartio ei ole tehnyt tehtävää<br>
- ! = vartion sijaluku laskettu tasapisteissä määräävien tehtävien perusteella
-</p>
-
-
+            {% endfor %}
+        </table>
+    {% else %}
+        <p>Ei tuloksia.</p>
+    {% endif %}
+    <p>
+        S = syöttämättä
+        <br>
+        H = vartion suoritus hylätty
+        <br>
+        K = vartio keskeyttänyt
+        <br>
+        E = vartio ei ole tehnyt tehtävää
+        <br>
+        ! = vartion sijaluku laskettu tasapisteissä määräävien tehtävien perusteella
+    </p>
 {% endblock %}

--- a/web/templates/tupa/tulokset.html
+++ b/web/templates/tupa/tulokset.html
@@ -47,9 +47,9 @@
                                         {% comment %} ylarivi {% endcomment %}
 
                                         {% if sarake.jarjestysnro %}
-                                        <td align="right" width=30 style="padding-right:10px;"><b>
-                                                {{ sarake.jarjestysnro }}.
-                                        </b></td>
+                                        <td align="right" width=30 style="padding-right:10px;">
+                                            <b>{{ sarake.jarjestysnro }}.</b>
+                                        </td>
                                         {% endif %}
                                 {% endif %}
                 {% endfor %}

--- a/web/templates/tupa/tuloksetHTML.html
+++ b/web/templates/tupa/tuloksetHTML.html
@@ -48,9 +48,9 @@
                                         {% comment %} ylarivi {% endcomment %}
 
                                         {% if sarake.jarjestysnro %}
-                                        <td align="right" width=30 style="padding-right:10px;"><b>
-                                                {{ sarake.jarjestysnro }}.
-                                        </b></td>
+                                        <td align="right" width=30 style="padding-right:10px;">
+                                            <b>{{ sarake.jarjestysnro }}.</b>
+                                        </td>
                                         {% endif %}
                                 {% endif %}
                 {% endfor %}

--- a/web/templates/tupa/tuloksetHTML.html
+++ b/web/templates/tupa/tuloksetHTML.html
@@ -1,197 +1,228 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Sarjakohtaiset tulokset</title>
-<link href="/kipamedia/favicon.ico" rel="icon" type="image/x-icon" />
-<style type="text/css">
-</style>
-
-
-</head>
-<body id="sarjakohtaiset_tulokset">
-{% load kipatags %}
-
-<table width="100%" border="0" id="tulostaulukko_otsikko">
-<tr valign="top">
-    <td width="33%"><h1 class="uppercase" style="margin:0; padding:0; line-height:normal;">{{kisa_nimi|alaviiva_pois}}</h1></td>
-    <td width="33%" align="center"><h1 style="line-height:normal;">{{heading}}</h1></td>
-    <td width="33%" align="right">&nbsp;</td>
-</tr>
-<tr>
-    <td>{%if kisa_aika %}
-            {{kisa_aika}}<br>
-        {% endif %}
-        {{kisa_paikka}}
-    </td>
-    <td align="center">{% now "j.n.Y G:i"%}</td>
-    <td align="right">&nbsp;</td>
-</tr>
-</table>
-
-{% if tulos_taulukko %}
-    <table id="tulostaulukko_screen" border=0 >
-        {% for rivi in tulos_taulukko%}
-                {%if forloop.counter|add:"3"|divisibleby:"5" %}
-                        <tr height="10"><td></td></tr>
-                {% endif %}
-                {% if forloop.first %}
-                      <tr>
-                {% for sarake in rivi %}
-                     {% comment %} ylarivi {% endcomment %}
-                                {% if forloop.first  %}
-                                        {% comment %} ylarivin eka {% endcomment %}
-                                        <td width="30" align="right"></td>
-                                        <td width="30" align="right" style="padding-right:10px;"><b></b></td>
-                                        <td style="min-width:100px;"></td>
-                                        <td align="right" width=30 style="padding-right:10px;"></td>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>Sarjakohtaiset tulokset</title>
+        <link href="/kipamedia/favicon.ico" rel="icon" type="image/x-icon" />
+        <style type="text/css"></style>
+    </head>
+    <body id="sarjakohtaiset_tulokset">
+        {% load kipatags %}
+        <table width="100%" border="0" id="tulostaulukko_otsikko">
+            <tr valign="top">
+                <td width="33%">
+                    <h1 class="uppercase" style="margin:0; padding:0; line-height:normal;">{{ kisa_nimi|alaviiva_pois }}</h1>
+                </td>
+                <td width="33%" align="center">
+                    <h1 style="line-height:normal;">{{ heading }}</h1>
+                </td>
+                <td width="33%" align="right">&nbsp;</td>
+            </tr>
+            <tr>
+                <td>
+                    {% if kisa_aika %}
+                        {{ kisa_aika }}
+                        <br>
+                    {% endif %}
+                    {{ kisa_paikka }}
+                </td>
+                <td align="center">{% now "j.n.Y G:i" %}</td>
+                <td align="right">&nbsp;</td>
+            </tr>
+        </table>
+        {% if tulos_taulukko %}
+            <table id="tulostaulukko_screen" border=0>
+                {% for rivi in tulos_taulukko %}
+                    {% if forloop.counter|add:"3"|divisibleby:"5" %}
+                        <tr height="10">
+                            <td></td>
+                        </tr>
+                    {% endif %}
+                    {% if forloop.first %}
+                        <tr>
+                            {% for sarake in rivi %}
+                                {% comment %} ylarivi {% endcomment %}
+                                {% if forloop.first %}
+                                    {% comment %} ylarivin eka {% endcomment %}
+                                    <td width="30" align="right"></td>
+                                    <td width="30" align="right" style="padding-right:10px;">
+                                        <b></b>
+                                    </td>
+                                    <td style="min-width:100px;"></td>
+                                    <td align="right" width=30 style="padding-right:10px;"></td>
                                 {% else %}
-                                        {% comment %} ylarivi {% endcomment %}
-
-                                        {% if sarake.jarjestysnro %}
+                                    {% comment %} ylarivi {% endcomment %}
+                                    {% if sarake.jarjestysnro %}
                                         <td align="right" width=30 style="padding-right:10px;">
                                             <b>{{ sarake.jarjestysnro }}.</b>
                                         </td>
-                                        {% endif %}
+                                    {% endif %}
                                 {% endif %}
-                {% endfor %}
-
-                      </tr>
-                      <tr valign="top">
-
-                        <td></td>
-                        {% for sarake in rivi %}
-                     {% comment %} ylarivi {% endcomment %}
-                                {% if forloop.first  %}
-                                        {% comment %} ylarivin eka {% endcomment %}
-                                        <td></td><td></td>
-                                {% else %}
-                                        {% comment %} ylarivi {% endcomment %}
-                                        {%if sarake.lyhenne %}
-                            {%if sarake.rastikasky %}
-                                                        <td align="right" style="padding-right:10px;"><b><a href=" {{sarake.rastikasky}} " target="_blank">{{sarake.lyhenne}}</a></b></td>
-                                                {% else %}
-                                                        <td align="right" style="padding-right:10px;"><b>{{sarake.lyhenne}}</b></td>
-                                                {% endif %}
-                                        {% else %}
-                                        <td align="right" width="60" style="padding-right:10px;"><b>
-                                            {{sarake.nimi|slice:":6"}}<br />
-                                            {{sarake.nimi|slice:"6:13"}}<br />
-                                            {{sarake.nimi|slice:"13:19"}}<br />
-                                            {{sarake.nimi|slice:"19:25"}}</b>
-                                        </td>
-                                        {% endif %}
-                                {% endif %}
-                        {%endfor %}
-
-                      </tr>
-                      <tr>
-                      <td></td><td></td><td align="right"><em>Maxpisteet</em></td>
-                        {% for sarake in rivi %}
-                                {% if forloop.first  %}
-                               <td align="right" style="padding-right:10px;"><em> {{ sarake.maksimipisteet }} </em></td>
-                                {% else %}
-
-                                {% if forloop.counter != 0 %}
-                                {% if forloop.counter != 1 %}
-                                {% if forloop.counter != 2 %}
-                                        <td align="right" style="padding-right:10px;"><em> {{ sarake.maksimipisteet }} </em></td>
-                                {% endif %}
-                                {% endif %}
-                                {% endif %}
-                                {% endif %}
-
-                        {%endfor %}
-                      </tr>
-                      <tr>
-                            <td width="30" align="right"><b>SIJ.</b></td>
-                            <td width="30" align="right" style="padding-right:10px;"><b></b></td>
-                            <td style="min-width:100px;"><b>VARTIO</b></td>
-                            <td align="right" width=30 style="padding-right:10px;"><b>YHT</b></td>
-                      </tr>
-
-                      <tr valign='top'>
-
-                {% else %}
-                {% for sarake in rivi %}
-                     {% comment %} ylarivi {% endcomment %}
-                     {% if forloop.counter == 2 %}
-                     {% comment %} ekasarake {% endcomment %}
-                        <td align="right" style="padding-right:10px;"> {{ sarake.nro }}</td> <td>{{sarake.nimi}}
-                                                {%if sarake.lippukunta %}<br>{%endif%}
-                                                {{sarake.lippukunta}}
-                                                {%if sarake.piiri %}<br>{%endif%}
-                                                {{sarake.piiri}}</td>
-                     {% else %}
-                     {% if forloop.counter == 3 %}
-                        <td align="right" style="padding-right:10px;">{{sarake}}</td>
-                     {% comment %} muut sarakkeet {% endcomment %}
-                     {% else %}
-                        <td align="right" style="padding-right:10px;">
-                                {% if forloop.first %} <b> {%endif%}
-                                        {{ sarake }}
-                                {% if forloop.first %} </b> {%endif%}
-                        </td>
-                     {% endif %}
-                     {% endif %}
-
-             {% endfor %}
-                     {% endif %}
-              </tr>
-               {% comment %} ULKONA OLEVAT: {% endcomment %}
-                {% if forloop.last %}
-                        <tr><td>&nbsp;  </td></tr>
-                        <tr><td> </td> <td></td><td><b>Ulkopuolella:</b> </td></tr>
-                        {% for rivi in ulkona_taulukko%}
-                        <tr valign='top'>
-                        {% for sarake in rivi %}
-
-
-                                {% if forloop.counter == 2 %}
-                                        {% comment %} ekasarake {% endcomment %}
-                                        <td align="right" style="padding-right:10px;">{{ sarake.nro }}</td> <td>{{ sarake.nimi }}
-                                                {%if sarake.lippukunta %}<br>{%endif%}
-                                                {{sarake.lippukunta}}
-                                                {%if sarake.piiri %}<br> {%endif%}
-                                                {{sarake.piiri}} </td>
-
-                                {% else %}
-                                        {% comment %} muut sarakkeet {% endcomment %}
-                                <td align="right" style="padding-right:10px;">
-                                        {% if forloop.first %} <b> {%endif%}
-                                        {{ sarake }}
-                                        {% if forloop.first %} </b> {%endif%}
-                                </td>
-                                {% endif %}
-                        {% endfor %}
+                            {% endfor %}
                         </tr>
-                        {%if forloop.counter|divisibleby:"5" %}
-                                        <tr height=10><td></td></tr>
+                        <tr valign="top">
+                            <td></td>
+                            {% for sarake in rivi %}
+                                {% comment %} ylarivi {% endcomment %}
+                                {% if forloop.first %}
+                                    {% comment %} ylarivin eka {% endcomment %}
+                                    <td></td>
+                                    <td></td>
+                                {% else %}
+                                    {% comment %} ylarivi {% endcomment %}
+                                    {% if sarake.lyhenne %}
+                                        {% if sarake.rastikasky %}
+                                            <td align="right" style="padding-right:10px;">
+                                                <b><a href=" {{ sarake.rastikasky }} " target="_blank">{{ sarake.lyhenne }}</a></b>
+                                            </td>
+                                        {% else %}
+                                            <td align="right" style="padding-right:10px;">
+                                                <b>{{ sarake.lyhenne }}</b>
+                                            </td>
+                                        {% endif %}
+                                    {% else %}
+                                        <td align="right" width="60" style="padding-right:10px;">
+                                            <b>
+                                                {{ sarake.nimi|slice:":6" }}
+                                                <br />
+                                                {{ sarake.nimi|slice:"6:13" }}
+                                                <br />
+                                                {{ sarake.nimi|slice:"13:19" }}
+                                                <br />
+                                            {{ sarake.nimi|slice:"19:25" }}</b>
+                                        </td>
+                                    {% endif %}
+                                {% endif %}
+                            {% endfor %}
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td></td>
+                            <td align="right">
+                                <em>Maxpisteet</em>
+                            </td>
+                            {% for sarake in rivi %}
+                                {% if forloop.first %}
+                                    <td align="right" style="padding-right:10px;">
+                                        <em>{{ sarake.maksimipisteet }}</em>
+                                    </td>
+                                {% else %}
+                                    {% if forloop.counter != 0 %}
+                                        {% if forloop.counter != 1 %}
+                                            {% if forloop.counter != 2 %}
+                                                <td align="right" style="padding-right:10px;">
+                                                    <em>{{ sarake.maksimipisteet }}</em>
+                                                </td>
+                                            {% endif %}
+                                        {% endif %}
+                                    {% endif %}
+                                {% endif %}
+                            {% endfor %}
+                        </tr>
+                        <tr>
+                            <td width="30" align="right">
+                                <b>SIJ.</b>
+                            </td>
+                            <td width="30" align="right" style="padding-right:10px;">
+                                <b></b>
+                            </td>
+                            <td style="min-width:100px;">
+                                <b>VARTIO</b>
+                            </td>
+                            <td align="right" width=30 style="padding-right:10px;">
+                                <b>YHT</b>
+                            </td>
+                        </tr>
+                        <tr valign='top'>
+                        {% else %}
+                            {% for sarake in rivi %}
+                                {% comment %} ylarivi {% endcomment %}
+                                {% if forloop.counter == 2 %}
+                                    {% comment %} ekasarake {% endcomment %}
+                                    <td align="right" style="padding-right:10px;">{{ sarake.nro }}</td>
+                                    <td>
+                                        {{ sarake.nimi }}
+                                        {% if sarake.lippukunta %}<br>{% endif %}
+                                        {{ sarake.lippukunta }}
+                                        {% if sarake.piiri %}<br>{% endif %}
+                                        {{ sarake.piiri }}
+                                    </td>
+                                {% else %}
+                                    {% if forloop.counter == 3 %}
+                                        <td align="right" style="padding-right:10px;">{{ sarake }}</td>
+                                        {% comment %} muut sarakkeet {% endcomment %}
+                                    {% else %}
+                                        <td align="right" style="padding-right:10px;">
+                                            {% if forloop.first %}<b>{% endif %}
+                                                {{ sarake }}
+                                                {% if forloop.first %}</b>{% endif %}
+                                        </td>
+                                    {% endif %}
+                                {% endif %}
+                            {% endfor %}
                         {% endif %}
+                    </tr>
+                    {% comment %} ULKONA OLEVAT: {% endcomment %}
+                    {% if forloop.last %}
+                        <tr>
+                            <td>&nbsp;</td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td></td>
+                            <td>
+                                <b>Ulkopuolella:</b>
+                            </td>
+                        </tr>
+                        {% for rivi in ulkona_taulukko %}
+                            <tr valign='top'>
+                                {% for sarake in rivi %}
+                                    {% if forloop.counter == 2 %}
+                                        {% comment %} ekasarake {% endcomment %}
+                                        <td align="right" style="padding-right:10px;">{{ sarake.nro }}</td>
+                                        <td>
+                                            {{ sarake.nimi }}
+                                            {% if sarake.lippukunta %}<br>{% endif %}
+                                            {{ sarake.lippukunta }}
+                                            {% if sarake.piiri %}<br>{% endif %}
+                                            {{ sarake.piiri }}
+                                        </td>
+                                    {% else %}
+                                        {% comment %} muut sarakkeet {% endcomment %}
+                                        <td align="right" style="padding-right:10px;">
+                                            {% if forloop.first %}<b>{% endif %}
+                                                {{ sarake }}
+                                                {% if forloop.first %}</b>{% endif %}
+                                        </td>
+                                    {% endif %}
+                                {% endfor %}
+                            </tr>
+                            {% if forloop.counter|divisibleby:"5" %}
+                                <tr height=10>
+                                    <td></td>
+                                </tr>
+                            {% endif %}
                         {% endfor %}
-                {% endif %}
-        {% endfor %}
-
-        <tr>
-        <br>
-        <br>
-        </tr>
-
-
-    </table>
-
-{% else %}
-    <p>Ei tuloksia.</p>
-{% endif %}
-
-<p>
- S = syöttämättä<br>
- H = vartion suoritus hylätty<br>
- K = vartio keskeyttänyt<br>
- E = vartio ei ole tehnyt tehtävää<br>
- ! = vartion sijaluku laskettu tasapisteissä määräävien tehtävien perusteella<br>
-</p>
-
-
-</body>
-
+                    {% endif %}
+                {% endfor %}
+                <tr>
+                    <br>
+                    <br>
+                </tr>
+            </table>
+        {% else %}
+            <p>Ei tuloksia.</p>
+        {% endif %}
+        <p>
+            S = syöttämättä
+            <br>
+            H = vartion suoritus hylätty
+            <br>
+            K = vartio keskeyttänyt
+            <br>
+            E = vartio ei ole tehnyt tehtävää
+            <br>
+            ! = vartion sijaluku laskettu tasapisteissä määräävien tehtävien perusteella
+            <br>
+        </p>
+    </body>
 </html>

--- a/web/templates/tupa/tuloksetHTML.html
+++ b/web/templates/tupa/tuloksetHTML.html
@@ -4,28 +4,6 @@
 <title>Sarjakohtaiset tulokset</title>
 <link href="/kipamedia/favicon.ico" rel="icon" type="image/x-icon" />
 <style type="text/css">
-<!--
-BODY {
-    Size: A4 landscape;
-    FONT-SIZE: 11px;
-    LINE-HEIGHT: 120%;
-    FONT-FAMILY: Tahoma, Verdana, Arial, Helvetica, sans-serif;
-    BACKGROUND-COLOR: white;
-    margin-top: 15px;
-    margin-left: 20px;
-}
-TD {
-    FONT-SIZE: 11px;
-    vertical-align:top;
-}
-
-@page figures {
-    size: landscape
-}
-
-.capitalize {text-transform:capitalize;}
-.uppercase  {text-transform:uppercase;}
--->
 </style>
 
 

--- a/web/templates/tupa/tulosta.html
+++ b/web/templates/tupa/tulosta.html
@@ -1,14 +1,12 @@
 {% extends "tupa/base.html" %}
 {% block title %}Tulokset sarjoittain{% endblock %}
 {% block content %}
-
-<h1>Tulokset sarjoittain</h1>
-
-<blockquote>
-{%for sarja in sarja_list %}
-      <a href='./sarja/{{sarja.id}}/' > {{sarja.nimi}} </a> <br>
-{% endfor %}
-</blockquote>
-
-{% endblock %}m
-
+    <h1>Tulokset sarjoittain</h1>
+    <blockquote>
+        {% for sarja in sarja_list %}
+            <a href='./sarja/{{ sarja.id }}/'>{{ sarja.nimi }}</a>
+            <br>
+        {% endfor %}
+    </blockquote>
+{% endblock %}
+m

--- a/web/templates/tupa/tulosta.html
+++ b/web/templates/tupa/tulosta.html
@@ -9,4 +9,3 @@
         {% endfor %}
     </blockquote>
 {% endblock %}
-m

--- a/web/templates/tupa/tuomarineuvos.html
+++ b/web/templates/tupa/tuomarineuvos.html
@@ -1,31 +1,22 @@
 {% extends "tupa/valitse.html" %}
-
 {% load kipatags %}
-
 {% block sarake %}
     <table width="600" border="1">
         <tr>
-        <td></td>
-                {% for kentta in sarake.tiedot.0.tehtavat %}
-                        <td>
-                                {{ kentta.nimi|alaviiva_pois }}
-                        </td>
-                {% endfor %}
+            <td></td>
+            {% for kentta in sarake.tiedot.0.tehtavat %}<td>{{ kentta.nimi|alaviiva_pois }}</td>{% endfor %}
         </tr>
         {% for rivi in sarake.tiedot %}
-                <tr>
-                <td>{{rivi.nimi}}</td>
-                {% for kentta in rivi.formit%}
-                     <td>{{ kentta }}{{kentta.errors}}</td>
-                {% endfor %}
-              </tr>
+            <tr>
+                <td>{{ rivi.nimi }}</td>
+                {% for kentta in rivi.formit %}<td>{{ kentta }}{{ kentta.errors }}</td>{% endfor %}
+            </tr>
         {% endfor %}
-   </table>
-{% endblock%}
+    </table>
+{% endblock %}
 {% block content %}
-        <form action="." method="post">
+    <form action="." method="post">
         {{ block.super }}
         {% include "tupa/tallenna.html" %}
-{% endblock%}
+    {% endblock %}
 </form>
-

--- a/web/templates/tupa/upload.html
+++ b/web/templates/tupa/upload.html
@@ -1,18 +1,12 @@
 {% extends "tupa/base.html" %}
-
 {% block title %}{{ heading }}{% endblock %}
 {% block content %}
-<h1> {{heading}} </h1>
-
-<form method="POST" action="" enctype="multipart/form-data">
-
-<br>
-<br>
-<br>
-
-{{form}}
-
-{% include "tupa/tallenna.html" %}
-</form>
+    <h1>{{ heading }}</h1>
+    <form method="POST" action="" enctype="multipart/form-data">
+        <br>
+        <br>
+        <br>
+        {{ form }}
+        {% include "tupa/tallenna.html" %}
+    </form>
 {% endblock %}
-

--- a/web/templates/tupa/upload_riisuttu.html
+++ b/web/templates/tupa/upload_riisuttu.html
@@ -1,19 +1,12 @@
 {% extends "tupa/base_riisuttu.html" %}
-
 {% block title %}{{ heading }}{% endblock %}
 {% block content %}
-<h1> {{heading}} </h1>
-
-<form method="POST" action="" enctype="multipart/form-data">
-
-<br>
-<br>
-<br>
-
-{{form}}
-
-{% include "tupa/tallenna.html" %}
-</form>
-
+    <h1>{{ heading }}</h1>
+    <form method="POST" action="" enctype="multipart/form-data">
+        <br>
+        <br>
+        <br>
+        {{ form }}
+        {% include "tupa/tallenna.html" %}
+    </form>
 {% endblock %}
-

--- a/web/templates/tupa/vaara_tietokanta.html
+++ b/web/templates/tupa/vaara_tietokanta.html
@@ -1,9 +1,11 @@
 {% if vanha_tietokanta %}
-VAROITUS!
-Järjestelmän tietokanta on epäyhteensopivaa versiota tai kirjoitussuojattu, joten kipa ei toimi oikein! <br><br>
-
-Mikäli tietokanta on epäyhteensopiva, voi kipan poistaa ja asentaa uudestaan. Kisat saa muutettua ottamalla vanhalla Kipa -versiolla xml tallenteen (tallenna kisa), ja tuomalla sen uuteen kipaan (palauta kisa)  <br>
-<br>
-Voi olla myös mahdollista että palvelinohjelmalla ei ole oikeuksia kirjoittaa web/ hakemistoon sekä tupa.db tietokantatiedostoon.<br>
+    VAROITUS!
+    Järjestelmän tietokanta on epäyhteensopivaa versiota tai kirjoitussuojattu, joten kipa ei toimi oikein!
+    <br>
+    <br>
+    Mikäli tietokanta on epäyhteensopiva, voi kipan poistaa ja asentaa uudestaan. Kisat saa muutettua ottamalla vanhalla Kipa -versiolla xml tallenteen (tallenna kisa), ja tuomalla sen uuteen kipaan (palauta kisa)
+    <br>
+    <br>
+    Voi olla myös mahdollista että palvelinohjelmalla ei ole oikeuksia kirjoittaa web/ hakemistoon sekä tupa.db tietokantatiedostoon.
+    <br>
 {% endif %}
-

--- a/web/templates/tupa/valitse.html
+++ b/web/templates/tupa/valitse.html
@@ -1,39 +1,31 @@
 {% extends "tupa/base.html" %}
 {% block title %}{{ heading }}{% endblock %}
-{% block header %}
-{% endblock %}
-
+{% block header %}{% endblock %}
 {% block content %}
-
-<h1>{{ heading }}</h1>
-
-{% block alku %}
-
-{% endblock %}
-
-
-{% if taulukko %}
-    <ul id="sarjatabs" class="shadetabs">
-        {% for sarake in taulukko %}
-            {% if sarake == taulukko.0  %}
-                <li><a href="#" rel="sarake{{ sarake.id }}" class="selected">{{ sarake.otsikko }}</a></li>
+    <h1>{{ heading }}</h1>
+    {% block alku %}{% endblock %}
+    {% if taulukko %}
+        <ul id="sarjatabs" class="shadetabs">
+            {% for sarake in taulukko %}
+                {% if sarake == taulukko.0 %}
+                    <li>
+                        <a href="#" rel="sarake{{ sarake.id }}" class="selected">{{ sarake.otsikko }}</a>
+                    </li>
                 {% else %}
-                <li><a href="#" rel="sarake{{ sarake.id }}">{{ sarake.otsikko }}</a></li>
-            {% endif %}
-        {% endfor %}
-    </ul>
-
-    <div style="border:1px solid gray; margin-bottom: 1em; padding: 10px">
-
-        {% for sarake in taulukko%}
-        <div id="sarake{{ sarake.id }}" class="tabcontent">
-            <ul id="tehtavatabs" class="">
-                 {% block sarake %} {{sarake}} {% endblock %}
-            </ul>
+                    <li>
+                        <a href="#" rel="sarake{{ sarake.id }}">{{ sarake.otsikko }}</a>
+                    </li>
+                {% endif %}
+            {% endfor %}
+        </ul>
+        <div style="border:1px solid gray; margin-bottom: 1em; padding: 10px">
+            {% for sarake in taulukko %}
+                <div id="sarake{{ sarake.id }}" class="tabcontent">
+                    <ul id="tehtavatabs" class="">
+                        {% block sarake %}{{ sarake }}{% endblock %}
+                    </ul>
+                </div>
+            {% endfor %}
         </div>
-        {% endfor %}
-    </div>
-{%endif%}
-
+    {% endif %}
 {% endblock %}
-

--- a/web/templates/tupa/valitse_form.html
+++ b/web/templates/tupa/valitse_form.html
@@ -1,19 +1,13 @@
 {% extends "tupa/valitse.html" %}
-
-{% block alku %}
-{{form}}
-{% endblock %}
-
-{% block sarake %}
-    {{ sarake }}
-{% endblock%}
+{% block alku %}{{ form }}{% endblock %}
+{% block sarake %}{{ sarake }}{% endblock %}
 {% block content %}
-<form method="POST" action="">
-{{ block.super }}
-{%if napin_tyyppi == "kopioi" %}
-{% include "tupa/kopioi.html" %}
-{% else %}
-{% include "tupa/tallenna.html" %}
-{% endif %}
-</form>
+    <form method="POST" action="">
+        {{ block.super }}
+        {% if napin_tyyppi == "kopioi" %}
+            {% include "tupa/kopioi.html" %}
+        {% else %}
+            {% include "tupa/tallenna.html" %}
+        {% endif %}
+    </form>
 {% endblock %}

--- a/web/templates/tupa/valitse_formset.html
+++ b/web/templates/tupa/valitse_formset.html
@@ -1,27 +1,30 @@
 {% extends "tupa/valitse.html" %}
-
 {% block alku %}
-<form method="POST" action="">
-{% include "tupa/tallenna.html" %}<br><br>
-{% endblock %}
-
-{% block sarake %}
-
-    {{ sarake.management_form }}
-<script type="text/javascript" language="javascript" src="/kipamedia/jquery.form-changed-warning.js"></script>
-
-<p><strong>Vaaditut kentät: Nro ja Nimi<br />
-Syötä 'Keskeyttänyt' ja 'Ulkopuolella' kenttiin sen tehtävän numero, josta lähtien vartio on sarjan ulkopuolella. <br />
-Keskeyttäneille vartioille ei enää syötetä tuloksia kyseisestä tehtävästä lähtien. <br />
-Sarjan ulkopuolelle siirtyneet vartiot saavat tulokset normaalisti, mutta niiden syötteitä ei käytetä esim. määriteltäessä interpoloinnissa nopeinta suoritusta.</strong></p>
-    {% for form in sarake.forms %}
-        <div class="oneRowInlineForm">
-            {{ form }}
-        </div>
-    {% endfor %}
-{% endblock%}
-{% block content %}
-{{ block.super }}
-{% include "tupa/tallenna.html" %}
-</form>
+    <form method="POST" action="">
+        {% include "tupa/tallenna.html" %}
+        <br>
+        <br>
+    {% endblock %}
+    {% block sarake %}
+        {{ sarake.management_form }}
+        <script type="text/javascript"
+                language="javascript"
+                src="/kipamedia/jquery.form-changed-warning.js"></script>
+        <p>
+            <strong>
+                Vaaditut kentät: Nro ja Nimi
+                <br />
+                Syötä 'Keskeyttänyt' ja 'Ulkopuolella' kenttiin sen tehtävän numero, josta lähtien vartio on sarjan ulkopuolella.
+                <br />
+                Keskeyttäneille vartioille ei enää syötetä tuloksia kyseisestä tehtävästä lähtien.
+                <br />
+                Sarjan ulkopuolelle siirtyneet vartiot saavat tulokset normaalisti, mutta niiden syötteitä ei käytetä esim. määriteltäessä interpoloinnissa nopeinta suoritusta.
+            </strong>
+        </p>
+        {% for form in sarake.forms %}<div class="oneRowInlineForm">{{ form }}</div>{% endfor %}
+    {% endblock %}
+    {% block content %}
+        {{ block.super }}
+        {% include "tupa/tallenna.html" %}
+    </form>
 {% endblock %}

--- a/web/templates/tupa/valitse_linkki.html
+++ b/web/templates/tupa/valitse_linkki.html
@@ -1,8 +1,8 @@
 {% extends "tupa/valitse.html" %}
-
 {% block sarake %}
     {% for taulu in sarake %}
-        <li><a href="{{taulu.linkki}}"> {{taulu.nimi}}</a></li>
+        <li>
+            <a href="{{ taulu.linkki }}">{{ taulu.nimi }}</a>
+        </li>
     {% endfor %}
-{% endblock%}
-
+{% endblock %}


### PR DESCRIPTION
Tämä PR on uusi yritys ottaa automaattinen muotoilu käyttöön myös näihin Django-templaatteihin. PR:ssä #48 kirjatut ongelmat templaattien rikkoutumisesta on ainakin pääsääntöisesti korjautunut tällä: https://github.com/djlint/djLint/pull/1001.

Formatointi-commitin sha lisätään .git-blame-ignore-revs:iin vasta sitten kun tätä ei enään rebaseteta eli tuo edellinen #73 on mergetty.