### PR TITLE
Tarkistussyötesivun taulukon navigoinnin korjaus

### DIFF
--- a/web/media/keyhandler.js
+++ b/web/media/keyhandler.js
@@ -1,19 +1,6 @@
 function checkForEnter(event) {
-  switch (event.keyCode) {
-    // up arrow
-    case 40:
-      $(this)
-        .parent()
-        .parent()
-        .next()
-        .children("td")
-        .children("input[class=" + $(this).attr("class") + "]")
-        .focus()
-        .select();
-      break;
-
-    // down arrow
-    case 38:
+  switch (event.originalEvent.key) {
+    case "ArrowUp":
       $(this)
         .parent()
         .parent()
@@ -24,8 +11,18 @@ function checkForEnter(event) {
         .select();
       break;
 
-    // Enter key
-    case 13:
+    case "ArrowDown":
+      $(this)
+        .parent()
+        .parent()
+        .next()
+        .children("td")
+        .children("input[class=" + $(this).attr("class") + "]")
+        .focus()
+        .select();
+      break;
+
+    case "Enter":
       $(this)
         .parent()
         .parent()
@@ -35,7 +32,5 @@ function checkForEnter(event) {
         .focus()
         .select();
       event.preventDefault();
-      return false;
-      break;
   }
 }

--- a/web/templates/tupa/syota_tehtava.html
+++ b/web/templates/tupa/syota_tehtava.html
@@ -23,11 +23,7 @@
 $(document).ready(function(){
     $("#taulukko").stickyTableHeaders();
 
-    if ($.browser.mozilla) {
-        $("input").keypress(checkForEnter);
-    } else {
-        $("input").keydown(checkForEnter);
-    }
+    $("input").keydown(checkForEnter);
 
     jQuery(function($){
        $.mask.definitions['~']='[he0123456789]'; /* hylätty, ei syötetty, numeroarvot*/

--- a/web/tupa/views.py
+++ b/web/tupa/views.py
@@ -534,6 +534,15 @@ def syotaTehtava(request, kisa_nimi, tehtava_id, talletettu=None, tarkistus=None
                 else:
                     formi.fields["arvo"].widget.attrs["class"] += " col" + str(colnum)
 
+                if "class" not in formi.fields["tarkistus"].widget.attrs.keys():
+                    formi.fields["tarkistus"].widget.attrs["class"] = "col" + str(
+                        colnum
+                    )
+                else:
+                    formi.fields["tarkistus"].widget.attrs["class"] += " col" + str(
+                        colnum
+                    )
+
                 if formi.is_valid():  # Talletetaan syöte
                     formi.save()
                 else:


### PR DESCRIPTION
Tämän pitäisi korjata issue #22.

Kyseinen ongelma siis johtui siitä, että pisteiden syöttöön käytetyssä taulukossa navigointi perustuu taulukon soluille asetetuille sarakkeen kertoville class-attribuuteille. Näitä atribuutteja ei asetettu tarkistussyötteen tapauksessa.